### PR TITLE
release(0.1.8): add cedar-lean to the workload catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "etna"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "ab_glyph",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["workloads/Test/harness"]
 
 [package]
 name = "etna"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 default-run = "etna"
 repository = "https://github.com/alpaylan/etna-cli"

--- a/docs/workloads/index.json
+++ b/docs/workloads/index.json
@@ -55,7 +55,9 @@
     { "name": "unicode-segmentation", "url": "https://github.com/alpaylan/unicode-segmentation-etna", "language": "Rust", "description": "unicode-segmentation fork with Etna variants (UAX#29 grapheme/word boundaries).", "default_ref": null, "status": "stable", "tags": ["crate-fork"] },
     { "name": "bitvec",               "url": "https://github.com/alpaylan/bitvec-rs-etna",            "language": "Rust", "description": "bitvec fork with Etna variants (bit-granularity memory management).",          "default_ref": null, "status": "stable", "tags": ["crate-fork"] },
     { "name": "indexmap",             "url": "https://github.com/alpaylan/indexmap-etna",             "language": "Rust", "description": "indexmap fork with Etna variants (hash table with stable iteration order).",    "default_ref": null, "status": "stable", "tags": ["crate-fork"] },
-    { "name": "ordered-float",        "url": "https://github.com/alpaylan/ordered-float-etna",        "language": "Rust", "description": "ordered-float fork with Etna variants.",                                       "default_ref": null, "status": "stable", "tags": ["crate-fork"] }
+    { "name": "ordered-float",        "url": "https://github.com/alpaylan/ordered-float-etna",        "language": "Rust", "description": "ordered-float fork with Etna variants.",                                       "default_ref": null, "status": "stable", "tags": ["crate-fork"] },
+
+    { "name": "cedar-lean", "url": "https://github.com/alpaylan/cedar-etna", "language": "Lean", "description": "Cedar (cedar-policy/cedar-spec) Lean 4 formalization with 9 patch-injected variants spanning typechecker / validator / SymCC encoder / level checker.", "default_ref": null, "status": "stable", "tags": ["spec-fork"] }
   ],
   "shared_libs": [
     { "name": "etna-haskell-lib", "url": "https://github.com/alpaylan/etna-haskell-lib", "consumed_by": "Haskell workloads",            "submodule_path": "./etna-lib" },


### PR DESCRIPTION
## Summary
- Adds **cedar-lean** to the workload catalog as the first Lean 4 entry
- Points at https://github.com/alpaylan/cedar-etna
- Bumps version 0.1.7 → 0.1.8 so dist/release.yml picks it up on the next tag

## Workload details
cedar-lean is built from the `cedar-policy/cedar-spec` Lean 4 formalization. It contains 9 patch-injected variants:

| Class | PR |
|---|---|
| validator soundness | #648 |
| SymCC encoder | #640, #855 |
| validator entity-existence | #779 |
| request-validation soundness | #658 |
| TypeEnv well-formedness | #689 |
| level-checker completeness | #573 |
| parser | #799, #877 |

`scripts/run_etna_experiment.py` and `bash scripts/validate_lean_workload.sh` work standalone; the full `etna experiment run` flow works after #3 + #4 in alpaylan/marauders are bumped (they enable native Lean recognition + grammar).

## Test plan
- [x] \`python3 -c \"import json; json.load(open('docs/workloads/index.json'))\"\` valid
- [x] \`cargo build --release\` produces \`etna v0.1.8\`
- [x] \`etna workload list --kind available\` surfaces cedar-lean under Lean
- [x] \`etna workload add cedar-lean\` (by catalog name) succeeds: clones repo, seeds tests/cedar-lean.json
- [ ] After merge: tag v0.1.8 to trigger the dist release pipeline

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 19f6b1116f0a1cddc2ba26b15f1318cea63641b1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->