### PR TITLE
release(0.1.9): bump marauders for Lean built-in support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -108,7 +108,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -560,12 +560,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "etna"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "ab_glyph",
  "anyhow",
@@ -1350,7 +1350,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "marauders"
 version = "0.0.13"
-source = "git+https://github.com/alpaylan/marauders.git?branch=main#15fab49658b95f1c51ef143458602bd06488c827"
+source = "git+https://github.com/alpaylan/marauders.git?branch=main#9d2b6c241e1753fd3ffe5ab3294973ec2fe06436"
 dependencies = [
  "anyhow",
  "clap",
@@ -1479,7 +1479,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2178,7 +2178,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2530,7 +2530,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3092,7 +3092,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["workloads/Test/harness"]
 
 [package]
 name = "etna"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 default-run = "etna"
 repository = "https://github.com/alpaylan/etna-cli"


### PR DESCRIPTION
## Summary
Refreshes the \`marauders = { git = \"...\", branch = \"main\" }\` lockfile entry to pull two merged PRs:
- alpaylan/marauders#3 — adds \`Language::Lean\` to the built-in enum
- alpaylan/marauders#4 — extends the pest grammar with \`/-\` and \`-/\` so inline mutation markers in \`.lean\` source parse

Bumps Cargo.toml 0.1.8 → 0.1.9.

## Why
Today, running cedar-lean in an experiment requires manually copying \`workloads/cedar-lean/marauder.toml\` to the experiment root so etna-cli's language check (\`Language::name_to_language(\"lean\", &custom_languages)\`) succeeds. With Lean as a builtin, that step disappears.

## Test plan
- [x] \`cargo update -p marauders\` resolves to commit 9d2b6c2 (post-#4)
- [x] \`cargo build --release\` succeeds
- [x] Fresh \`etna experiment new\` + \`etna workload add cedar-lean\` + \`etna experiment amend-test --strategy plausible\` + \`etna experiment run\` succeed **without** any \`marauder.toml\` at the experiment root
- [x] 90-row store.jsonl produced; Plausible finds 6/9 variants