### PR TITLE
feat(experiment): add publish-page subcommand + reusable run-and-publish workflow

### DIFF
--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -1,0 +1,232 @@
+name: Run experiment and publish to Cloudflare Pages
+# Reusable workflow: every workload's repo calls this with `uses:` to run an
+# `etna experiment run` and publish the results (HTML + JSON + raw store +
+# manifest) to a per-workload Cloudflare Pages project.
+#
+# What the caller does:
+#   1. Adds .github/workflows/publish.yml with `uses:
+#      alpaylan/etna-cli/.github/workflows/run-and-publish.yml@<ref>`
+#   2. Sets the secrets CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID
+#
+# Default cf-pages-project is the workload's `name` from its `etna.toml`.
+
+on:
+  workflow_call:
+    inputs:
+      strategy:
+        description: 'Strategy to amend onto every task (e.g. plausible, etna, proptest)'
+        type: string
+        default: plausible
+      trials:
+        description: 'Trials per (variant, property)'
+        type: number
+        default: 10
+      timeout:
+        description: 'Per-trial timeout in seconds'
+        type: number
+        default: 60
+      cf-pages-project:
+        description: 'Cloudflare Pages project to deploy into. Empty = use the workload name from etna.toml.'
+        type: string
+        default: ''
+      etna-version:
+        description: 'etna-cli release tag to install (e.g. v0.1.10). Empty = latest release.'
+        type: string
+        default: ''
+    secrets:
+      CLOUDFLARE_API_TOKEN:
+        required: true
+      CLOUDFLARE_ACCOUNT_ID:
+        required: true
+
+# One deploy at a time; cancel a still-running older run if a newer push arrives.
+concurrency:
+  group: run-and-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      deployments: write
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # marauders applies patches; full history avoids surprise reset behaviour
+
+      # ---------- Read workload metadata --------------------------------
+      - name: Detect language from etna.toml
+        id: meta
+        shell: bash
+        run: |
+          if [ ! -f etna.toml ]; then
+            echo "::error::etna.toml not found at repo root"
+            exit 1
+          fi
+          name=$(grep -E '^name *= *"' etna.toml | head -1 | sed -E 's/^name *= *"([^"]*)".*/\1/')
+          language=$(grep -E '^language *= *"' etna.toml | head -1 | sed -E 's/^language *= *"([^"]*)".*/\1/' | tr '[:upper:]' '[:lower:]')
+          if [ -z "$name" ] || [ -z "$language" ]; then
+            echo "::error::Could not parse name/language from etna.toml"
+            exit 1
+          fi
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "language=$language" >> "$GITHUB_OUTPUT"
+          if [ -n "${{ inputs.cf-pages-project }}" ]; then
+            echo "project=${{ inputs.cf-pages-project }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "project=$name" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Detected workload: name=$name language=$language"
+
+      # ---------- Per-language toolchain bootstrap + cache --------------
+      - name: Setup Rust
+        if: steps.meta.outputs.language == 'rust'
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache Rust
+        if: steps.meta.outputs.language == 'rust'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ steps.meta.outputs.name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-${{ steps.meta.outputs.name }}-
+
+      - name: Setup Haskell + Stack
+        if: steps.meta.outputs.language == 'haskell'
+        uses: haskell-actions/setup@v2
+        with:
+          enable-stack: true
+          stack-version: latest
+      - name: Cache Stack
+        if: steps.meta.outputs.language == 'haskell'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.stack
+            .stack-work
+          key: ${{ runner.os }}-stack-${{ steps.meta.outputs.name }}-${{ hashFiles('**/stack.yaml*', '**/*.cabal', '**/package.yaml') }}
+          restore-keys: ${{ runner.os }}-stack-${{ steps.meta.outputs.name }}-
+
+      - name: Setup OCaml
+        if: steps.meta.outputs.language == 'ocaml'
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: '5.x'
+      - name: Cache OCaml build artefacts
+        if: steps.meta.outputs.language == 'ocaml'
+        uses: actions/cache@v4
+        with:
+          path: |
+            _build
+          key: ${{ runner.os }}-ocaml-${{ steps.meta.outputs.name }}-${{ hashFiles('**/dune-project', '**/*.opam') }}
+          restore-keys: ${{ runner.os }}-ocaml-${{ steps.meta.outputs.name }}-
+
+      - name: Setup Coq (Rocq)
+        if: steps.meta.outputs.language == 'rocq' || steps.meta.outputs.language == 'coq'
+        uses: coq-community/docker-coq-action@v1
+        with:
+          custom_image: 'coqorg/coq:8.20'
+          custom_script: 'echo "Coq image pre-pulled"'
+
+      - name: Install elan (Lean toolchain)
+        if: steps.meta.outputs.language == 'lean'
+        shell: bash
+        run: |
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+            | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      - name: Cache lake build (Lean)
+        if: steps.meta.outputs.language == 'lean'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.elan
+            **/.lake/build
+            **/.lake/packages
+          key: ${{ runner.os }}-lake-${{ steps.meta.outputs.name }}-${{ hashFiles('**/lean-toolchain', '**/lake-manifest.json') }}
+          restore-keys: ${{ runner.os }}-lake-${{ steps.meta.outputs.name }}-
+
+      # ---------- Install etna-cli ------------------------------------
+      - name: Install etna-cli
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.etna-version }}" ]; then
+            url="https://github.com/alpaylan/etna-cli/releases/download/${{ inputs.etna-version }}/etna-installer.sh"
+          else
+            url="https://github.com/alpaylan/etna-cli/releases/latest/download/etna-installer.sh"
+          fi
+          curl -LsSf "$url" | sh
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          # Verify installed
+          "$HOME/.cargo/bin/etna" --version || true
+
+      # ---------- Set up experiment + workload --------------------------
+      # `etna workload add` clones from a git URL. We pass the current repo's
+      # URL + SHA so the workload mirrors what's in CI exactly.
+      - name: Create experiment + add workload
+        shell: bash
+        run: |
+          mkdir -p /tmp/etna-experiment
+          cd /tmp/etna-experiment
+          etna experiment new ci-run
+          cd ci-run
+          etna workload add "https://github.com/${{ github.repository }}.git" --ref "${{ github.sha }}"
+          ls tests/
+
+      - name: Amend test with strategy
+        shell: bash
+        run: |
+          cd /tmp/etna-experiment/ci-run
+          test_name="${{ steps.meta.outputs.name }}"
+          etna experiment amend-test --test "$test_name" --strategy "${{ inputs.strategy }}"
+
+      # ---------- Run + publish ----------------------------------------
+      - name: Run experiment
+        shell: bash
+        run: |
+          cd /tmp/etna-experiment/ci-run
+          test_name="${{ steps.meta.outputs.name }}"
+          etna experiment run --tests "$test_name" \
+            --params trials=${{ inputs.trials }} \
+            --params timeout=${{ inputs.timeout }}
+
+      - name: Bundle results into dist/
+        shell: bash
+        run: |
+          cd /tmp/etna-experiment/ci-run
+          etna experiment publish-page --output "$GITHUB_WORKSPACE/dist"
+          ls -la "$GITHUB_WORKSPACE/dist"
+          echo "--- size ---"
+          du -sh "$GITHUB_WORKSPACE/dist"
+          du -h "$GITHUB_WORKSPACE/dist"/*
+
+      # ---------- Cloudflare Pages -------------------------------------
+      # Wrangler's `pages deploy` does NOT auto-create the project — it
+      # errors when the name is unknown. Create it first; ignore failures
+      # (CLI returns non-zero when the project already exists).
+      - name: Ensure Cloudflare Pages project exists
+        uses: cloudflare/wrangler-action@v3
+        continue-on-error: true
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages project create ${{ steps.meta.outputs.project }} --production-branch=main
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=${{ steps.meta.outputs.project }} --branch=main --commit-dirty=true
+
+      - name: Print result URL
+        shell: bash
+        run: |
+          echo "Deployed to https://${{ steps.meta.outputs.project }}.pages.dev/"
+          echo "JSON endpoint: https://${{ steps.meta.outputs.project }}.pages.dev/report.json"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -207,7 +207,8 @@ pub(crate) fn run() -> anyhow::Result<()> {
             }
             ExperimentCommand::Visualize { name: _, figure, tests, groupby, aggby, metric, buckets, max, visualization_type, hatched } => commands::experiment::visualize::invoke(mgr, experiment.unwrap(), figure, tests, groupby, aggby, metric, buckets, max, visualization_type, hatched),
             ExperimentCommand::VisualizeJson { input, output } => commands::experiment::visualize::draw_bucket_chart_from_json(&input, &output),
-            ExperimentCommand::Report { name: _, output, publish, strip_counterexamples } => commands::experiment::report::invoke(mgr, experiment.unwrap(), output, publish, strip_counterexamples),
+            ExperimentCommand::Report { name: _, output, publish, strip_counterexamples, json_output } => commands::experiment::report::invoke(mgr, experiment.unwrap(), output, publish, strip_counterexamples, json_output),
+            ExperimentCommand::PublishPage { name: _, output, strip_counterexamples } => commands::experiment::publish_page::invoke(mgr, experiment.unwrap(), output, strip_counterexamples),
             ExperimentCommand::List {} => commands::experiment::list::invoke(mgr),
         },
         Command::Workload(wl) => match wl {
@@ -447,6 +448,29 @@ enum ExperimentCommand {
         /// at the cost of losing them from the interactive report.
         #[clap(long, default_value = "false")]
         strip_counterexamples: bool,
+        /// Also dump the report's metrics payload as a standalone JSON file
+        /// (the same data the HTML embeds, gzip-decoded and indented). Useful
+        /// for serving a static `/json` endpoint alongside the HTML report.
+        #[clap(long)]
+        json_output: Option<PathBuf>,
+    },
+    #[clap(
+        name = "publish-page",
+        about = "Bundle experiment results into a Cloudflare-Pages-ready directory"
+    )]
+    PublishPage {
+        /// Name of the experiment
+        /// [default: current directory]
+        #[clap(short, long)]
+        name: Option<String>,
+        /// Output directory (created if missing). Receives index.html,
+        /// report.html, report.json, store.jsonl, and etna.toml.
+        #[clap(short, long)]
+        output: PathBuf,
+        /// Drop per-trial `counterexample` fields from the embedded metrics
+        /// payload. Same effect as on `report`.
+        #[clap(long, default_value = "false")]
+        strip_counterexamples: bool,
     },
     #[clap(name = "list", about = "List all experiments")]
     List {},
@@ -676,6 +700,7 @@ impl Command {
                 ExperimentCommand::Visualize { name, .. } => name.as_ref(),
                 ExperimentCommand::VisualizeJson { .. } => None,
                 ExperimentCommand::Report { name, .. } => name.as_ref(),
+                ExperimentCommand::PublishPage { name, .. } => name.as_ref(),
                 ExperimentCommand::List { .. } => None,
             },
             Command::Workload(wl) => match wl {
@@ -704,6 +729,7 @@ impl Command {
                 ExperimentCommand::Visualize { .. } => true,
                 ExperimentCommand::VisualizeJson { .. } => false,
                 ExperimentCommand::Report { .. } => true,
+                ExperimentCommand::PublishPage { .. } => true,
                 ExperimentCommand::List { .. } => false,
             },
             Command::Workload(wl) => match wl {

--- a/src/commands/experiment/mod.rs
+++ b/src/commands/experiment/mod.rs
@@ -3,6 +3,7 @@ pub mod clone;
 pub mod create_test;
 pub mod list;
 pub mod new;
+pub mod publish_page;
 pub mod register;
 pub mod report;
 pub mod run;

--- a/src/commands/experiment/publish_page.rs
+++ b/src/commands/experiment/publish_page.rs
@@ -1,0 +1,304 @@
+//! `etna experiment publish-page` — bundle an experiment's results plus the
+//! workload's manifest into a directory ready to drop onto Cloudflare Pages.
+//!
+//! Output layout:
+//! ```text
+//! <out>/
+//!   index.html        — small landing page: workload description card,
+//!                        summary stats, iframe(report.html)
+//!   report.html       — output of `etna experiment report`
+//!   report.json       — same metrics payload, exposed for /json
+//!   store.jsonl       — verbatim per-trial rows
+//!   etna.toml         — copy of the workload manifest
+//! ```
+//!
+//! For multi-workload experiments (rare in CI), each workload after the
+//! first goes under `<out>/workloads/<name>/`. Single-workload experiments
+//! write at the root so `https://<workload>.pages.dev/` shows the page
+//! directly.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::commands::experiment::report::{render_html_from_payload, ReportPayload};
+use crate::error_context::Context;
+use crate::experiment::ExperimentMetadata;
+use crate::manager::Manager;
+use crate::workload::WorkloadManifest;
+
+/// Aggregate per-property status counts for the summary card on `index.html`.
+fn summarise(payload: &ReportPayload, workload_name: &str) -> Vec<PropertySummary> {
+    let mut by_prop: HashMap<String, StatusCounter> = HashMap::new();
+    for row in &payload.metrics {
+        let row_workload = row
+            .get("workload")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        if !row_workload.eq_ignore_ascii_case(workload_name) {
+            continue;
+        }
+        let prop = row
+            .get("property")
+            .and_then(|v| v.as_str())
+            .unwrap_or("?")
+            .to_string();
+        let status = row
+            .get("status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("?")
+            .to_string();
+        let entry = by_prop.entry(prop).or_default();
+        match status.as_str() {
+            "passed" => entry.passed += 1,
+            "failed" => entry.failed += 1,
+            _ => entry.other += 1,
+        }
+    }
+    let mut out: Vec<PropertySummary> = by_prop
+        .into_iter()
+        .map(|(property, c)| PropertySummary {
+            property,
+            passed: c.passed,
+            failed: c.failed,
+            other: c.other,
+        })
+        .collect();
+    out.sort_by(|a, b| a.property.cmp(&b.property));
+    out
+}
+
+#[derive(Default)]
+struct StatusCounter {
+    passed: usize,
+    failed: usize,
+    other: usize,
+}
+
+struct PropertySummary {
+    property: String,
+    passed: usize,
+    failed: usize,
+    other: usize,
+}
+
+/// HTML escape for plaintext content. Bytes only — assumes UTF-8 input.
+fn h(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+fn render_index(
+    manifest: &WorkloadManifest,
+    summary: &[PropertySummary],
+    generated_at: &str,
+) -> String {
+    let total: usize = summary.iter().map(|p| p.passed + p.failed + p.other).sum();
+    let total_failed: usize = summary.iter().map(|p| p.failed).sum();
+    let total_passed: usize = summary.iter().map(|p| p.passed).sum();
+
+    let summary_rows: String = summary
+        .iter()
+        .map(|p| {
+            let bug_class = if p.failed > 0 { "found" } else { "missed" };
+            format!(
+                "<tr><td><code>{prop}</code></td><td class=\"num\">{pass}</td><td class=\"num\">{fail}</td><td class=\"num\">{other}</td><td class=\"verdict {bug_class}\">{verdict}</td></tr>",
+                prop = h(&p.property),
+                pass = p.passed,
+                fail = p.failed,
+                other = p.other,
+                bug_class = bug_class,
+                verdict = if p.failed > 0 { "bug found" } else { "—" },
+            )
+        })
+        .collect();
+
+    let crate_line = if let Some(c) = &manifest.crate_name {
+        format!("<div class=\"meta\"><strong>Crate:</strong> <code>{}</code></div>", h(c))
+    } else {
+        String::new()
+    };
+
+    let base_commit_line = if let Some(b) = &manifest.base_commit {
+        format!(
+            "<div class=\"meta\"><strong>Base commit:</strong> <code>{}</code></div>",
+            h(&b[..b.len().min(12)])
+        )
+    } else {
+        String::new()
+    };
+
+    format!(
+        r#"<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{name} — etna results</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  :root {{ color-scheme: light dark; --fg:#1a1a1a; --bg:#fafafa; --muted:#666; --border:#ddd; --accent:#0353a4; --found:#b03a2e; --missed:#666; }}
+  @media (prefers-color-scheme: dark) {{ :root {{ --fg:#e6e6e6; --bg:#0f0f0f; --muted:#999; --border:#333; --accent:#80b3ff; --found:#ff7766; --missed:#888; }} }}
+  body {{ margin:0; font:14px/1.5 -apple-system,BlinkMacSystemFont,system-ui,sans-serif; color:var(--fg); background:var(--bg); }}
+  header {{ padding: 24px max(24px, calc((100vw - 1100px) / 2)); border-bottom:1px solid var(--border); }}
+  header h1 {{ margin: 0 0 8px; font-size: 22px; }}
+  header .lang {{ display:inline-block; padding:2px 8px; background:var(--accent); color:#fff; border-radius:3px; font-size:12px; vertical-align:middle; }}
+  main {{ padding: 24px max(24px, calc((100vw - 1100px) / 2)); }}
+  .desc {{ white-space: pre-wrap; max-width: 70ch; color:var(--fg); margin: 0 0 24px; }}
+  .meta {{ color:var(--muted); font-size:13px; margin: 4px 0; }}
+  .summary {{ margin: 24px 0; border:1px solid var(--border); border-radius:6px; overflow:hidden; }}
+  .summary h2 {{ margin:0; padding: 12px 16px; background: rgba(127,127,127,0.08); font-size:15px; }}
+  .summary table {{ width:100%; border-collapse: collapse; }}
+  .summary th, .summary td {{ padding: 8px 16px; text-align: left; border-top:1px solid var(--border); }}
+  .summary th {{ font-weight:600; color:var(--muted); }}
+  .summary .num {{ text-align:right; font-variant-numeric: tabular-nums; }}
+  .summary .verdict.found {{ color:var(--found); font-weight:600; }}
+  .summary .verdict.missed {{ color:var(--missed); }}
+  .links a {{ display:inline-block; margin-right: 16px; color:var(--accent); }}
+  .links {{ margin: 16px 0 24px; font-size: 13px; }}
+  iframe {{ width:100%; height: 90vh; border:1px solid var(--border); border-radius:6px; background:#fff; }}
+  footer {{ padding: 16px max(24px, calc((100vw - 1100px) / 2)); color:var(--muted); font-size:12px; border-top:1px solid var(--border); margin-top: 24px; }}
+  code {{ font:13px/1.4 ui-monospace,"SF Mono",Menlo,monospace; }}
+</style>
+</head>
+<body>
+<header>
+  <h1>{name} <span class="lang">{language}</span></h1>
+  <div class="meta">Total: {total} trials · {total_passed} passed · {total_failed} failed</div>
+</header>
+<main>
+  <p class="desc">{description}</p>
+  {crate_line}
+  {base_commit_line}
+  <div class="summary">
+    <h2>Per-property results</h2>
+    <table>
+      <thead><tr><th>Property</th><th class="num">passed</th><th class="num">failed</th><th class="num">other</th><th>verdict</th></tr></thead>
+      <tbody>{rows}</tbody>
+    </table>
+  </div>
+  <div class="links">
+    <a href="./report.html">Interactive report ↗</a>
+    <a href="./report.json">JSON (/report.json)</a>
+    <a href="./store.jsonl">Raw store (/store.jsonl)</a>
+    <a href="./etna.toml">etna.toml</a>
+  </div>
+  <iframe src="./report.html" title="Interactive report"></iframe>
+</main>
+<footer>Generated {generated_at} by <code>etna experiment publish-page</code>.</footer>
+</body>
+</html>
+"#,
+        name = h(&manifest.name),
+        language = h(&manifest.language),
+        description = h(manifest.description.as_deref().unwrap_or("")),
+        crate_line = crate_line,
+        base_commit_line = base_commit_line,
+        total = total,
+        total_passed = total_passed,
+        total_failed = total_failed,
+        rows = summary_rows,
+        generated_at = h(generated_at),
+    )
+}
+
+pub fn invoke(
+    mut mgr: Manager,
+    experiment: ExperimentMetadata,
+    output: PathBuf,
+    strip_counterexamples: bool,
+) -> anyhow::Result<()> {
+    fs::create_dir_all(&output)
+        .with_context(|| format!("Failed to create output directory '{}'", output.display()))?;
+
+    let payload = ReportPayload::build(&mut mgr, &experiment, strip_counterexamples)?;
+    let html = render_html_from_payload(&payload)?;
+    let json = payload.to_json_pretty()?;
+
+    let workloads = experiment.workloads();
+    if workloads.is_empty() {
+        anyhow::bail!("Experiment '{}' has no workloads to publish", experiment.name);
+    }
+
+    // Single-workload experiments lay out at the dist root so
+    // `<workload>.pages.dev/` is the workload page.
+    if workloads.len() == 1 {
+        write_workload_page(
+            &output,
+            &mgr,
+            &experiment,
+            &workloads[0].name,
+            &payload,
+            &html,
+            &json,
+        )?;
+    } else {
+        // First workload at root, rest under workloads/<name>/
+        let mut iter = workloads.into_iter();
+        let first = iter.next().expect("non-empty");
+        write_workload_page(
+            &output,
+            &mgr,
+            &experiment,
+            &first.name,
+            &payload,
+            &html,
+            &json,
+        )?;
+        for wl in iter {
+            let sub = output.join("workloads").join(&wl.name);
+            fs::create_dir_all(&sub).with_context(|| {
+                format!("Failed to create directory '{}'", sub.display())
+            })?;
+            write_workload_page(&sub, &mgr, &experiment, &wl.name, &payload, &html, &json)?;
+        }
+    }
+
+    tracing::info!("Published page to {}", output.display());
+    Ok(())
+}
+
+fn write_workload_page(
+    out: &Path,
+    _mgr: &Manager,
+    experiment: &ExperimentMetadata,
+    workload_name: &str,
+    payload: &ReportPayload,
+    html: &str,
+    json: &str,
+) -> anyhow::Result<()> {
+    fs::write(out.join("report.html"), html).context("Failed to write report.html")?;
+    fs::write(out.join("report.json"), json).context("Failed to write report.json")?;
+
+    // Copy the experiment's store (verbatim per-trial rows). Store may
+    // have been written by a previous run; if it's missing, leave a stub.
+    if experiment.store.is_file() {
+        fs::copy(&experiment.store, out.join("store.jsonl"))
+            .context("Failed to copy store.jsonl")?;
+    } else {
+        fs::write(out.join("store.jsonl"), "")
+            .context("Failed to write empty store.jsonl")?;
+    }
+
+    let dir = experiment
+        .workload_path(workload_name)
+        .with_context(|| format!("Workload '{}' not found in experiment", workload_name))?;
+    let manifest = WorkloadManifest::read(&dir).with_context(|| {
+        format!("Failed to read etna.toml for workload '{}'", workload_name)
+    })?;
+
+    // Copy the raw etna.toml (pretty Rust-side serialisation would lose
+    // user comments — the verbatim file is what consumers want).
+    let etna_toml_src = dir.join("etna.toml");
+    if etna_toml_src.is_file() {
+        fs::copy(&etna_toml_src, out.join("etna.toml"))
+            .context("Failed to copy etna.toml")?;
+    }
+
+    let summary = summarise(payload, &manifest.name);
+    let index = render_index(&manifest, &summary, &payload.generated_at);
+    fs::write(out.join("index.html"), index).context("Failed to write index.html")?;
+
+    Ok(())
+}

--- a/src/commands/experiment/report.rs
+++ b/src/commands/experiment/report.rs
@@ -80,6 +80,68 @@ fn publish_gist(path: &std::path::Path) -> anyhow::Result<String> {
     Ok(format!("Gist: {}\nView: {}", gist_url, view_url))
 }
 
+/// The serialisable payload that backs both `render_html` and any JSON-only
+/// sink (e.g. the `--json-output` flag). Separated so the two outputs share
+/// the exact same underlying data.
+pub struct ReportPayload {
+    pub experiment_name: String,
+    pub generated_at: String,
+    pub metrics: Vec<serde_json::Value>,
+    pub workload_docs: serde_json::Map<String, serde_json::Value>,
+}
+
+impl ReportPayload {
+    /// Read the experiment store and assemble the payload. Side effect:
+    /// loads metrics into `mgr`'s store.
+    pub fn build(
+        mgr: &mut Manager,
+        experiment: &ExperimentMetadata,
+        strip_counterexamples: bool,
+    ) -> anyhow::Result<Self> {
+        mgr.set_store_path(experiment.store.clone())?;
+        mgr.require_store_mut()?.load_metrics()?;
+
+        let metrics: Vec<serde_json::Value> = mgr
+            .require_store()?
+            .metrics
+            .iter()
+            .map(|m| {
+                let mut obj = m.data.clone();
+                if strip_counterexamples {
+                    obj.remove("counterexample");
+                }
+                obj.insert(
+                    "hash".to_string(),
+                    serde_json::Value::String(m.hash.clone()),
+                );
+                serde_json::Value::Object(obj)
+            })
+            .collect();
+
+        let workload_docs = load_workload_docs(experiment);
+        let generated_at = chrono::Utc::now().format("%Y-%m-%d %H:%M UTC").to_string();
+
+        Ok(Self {
+            experiment_name: experiment.name.clone(),
+            generated_at,
+            metrics,
+            workload_docs,
+        })
+    }
+
+    /// Serialise as a single JSON document. Stable shape used by the
+    /// `--json-output` flag and by `experiment publish-page` for `/json`.
+    pub fn to_json_pretty(&self) -> anyhow::Result<String> {
+        let body = serde_json::json!({
+            "experiment": self.experiment_name,
+            "generated_at": self.generated_at,
+            "workload_docs": self.workload_docs,
+            "metrics": self.metrics,
+        });
+        Ok(serde_json::to_string_pretty(&body)?)
+    }
+}
+
 /// Render the report HTML for an experiment without writing it to disk.
 /// Side effects: loads the experiment store into `mgr`.
 ///
@@ -92,31 +154,15 @@ pub fn render_html(
     experiment: &ExperimentMetadata,
     strip_counterexamples: bool,
 ) -> anyhow::Result<String> {
-    // Load metrics
-    mgr.set_store_path(experiment.store.clone())?;
-    mgr.require_store_mut()?.load_metrics()?;
+    let payload = ReportPayload::build(mgr, experiment, strip_counterexamples)?;
+    render_html_from_payload(&payload)
+}
 
-    let metrics: Vec<serde_json::Value> = mgr
-        .require_store()?
-        .metrics
-        .iter()
-        .map(|m| {
-            let mut obj = m.data.clone();
-            if strip_counterexamples {
-                obj.remove("counterexample");
-            }
-            obj.insert(
-                "hash".to_string(),
-                serde_json::Value::String(m.hash.clone()),
-            );
-            serde_json::Value::Object(obj)
-        })
-        .collect();
-
-    // Load workload docs for mutation matrix filtering
-    let workload_docs = load_workload_docs(experiment);
-
-    let metrics_json_raw = serde_json::to_string(&metrics)?;
+/// Same as `render_html` but takes a pre-built payload, so callers (e.g.
+/// `publish-page`) can render HTML and JSON from the same source without
+/// re-reading the store.
+pub fn render_html_from_payload(payload: &ReportPayload) -> anyhow::Result<String> {
+    let metrics_json_raw = serde_json::to_string(&payload.metrics)?;
 
     // Gzip-compress and base64-encode metrics to keep the HTML under GitHub's 1MB API limit
     let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
@@ -130,10 +176,9 @@ pub fn render_html(
         compressed.len(),
         metrics_b64.len()
     );
-    let experiment_name_json = serde_json::to_string(&experiment.name)?;
-    let workload_docs_json = serde_json::to_string(&workload_docs)?;
-    let generated_at = chrono::Utc::now().format("%Y-%m-%d %H:%M UTC").to_string();
-    let generated_at_json = serde_json::to_string(&generated_at)?;
+    let experiment_name_json = serde_json::to_string(&payload.experiment_name)?;
+    let workload_docs_json = serde_json::to_string(&payload.workload_docs)?;
+    let generated_at_json = serde_json::to_string(&payload.generated_at)?;
 
     // Render template with minijinja
     let mut env = minijinja::Environment::new();
@@ -142,7 +187,7 @@ pub fn render_html(
 
     let tmpl = env.get_template("report.html")?;
     let html = tmpl.render(minijinja::context! {
-        experiment_name => &experiment.name,
+        experiment_name => &payload.experiment_name,
         metrics_b64 => &metrics_b64,
         experiment_name_json => &experiment_name_json,
         workload_docs_json => &workload_docs_json,
@@ -158,13 +203,20 @@ pub fn invoke(
     output: Option<PathBuf>,
     publish: bool,
     strip_counterexamples: bool,
+    json_output: Option<PathBuf>,
 ) -> anyhow::Result<()> {
-    let html = render_html(&mut mgr, &experiment, strip_counterexamples)?;
+    let payload = ReportPayload::build(&mut mgr, &experiment, strip_counterexamples)?;
+    let html = render_html_from_payload(&payload)?;
 
     let output_path = output.unwrap_or_else(|| experiment.path.join("report.html"));
     std::fs::write(&output_path, &html).context("Failed to write report HTML")?;
-
     tracing::info!("Report written to {}", output_path.display());
+
+    if let Some(json_path) = json_output {
+        let body = payload.to_json_pretty()?;
+        std::fs::write(&json_path, body).context("Failed to write report JSON")?;
+        tracing::info!("Report JSON written to {}", json_path.display());
+    }
 
     if publish {
         let result = publish_gist(&output_path)?;


### PR DESCRIPTION
## Summary
Per the discussion in chat: every workload should auto-run an experiment on push to main and publish results to its own Cloudflare Pages project, with a `/json` endpoint and the workload description shown alongside the report.

This PR adds the etna-cli pieces:

### 1. `etna experiment report --json-output <path>`
Writes the same metrics payload the HTML embeds as a standalone, indented JSON. Lets you serve `/json` next to `/report.html`.

### 2. `etna experiment publish-page --output <dir>` (new subcommand)
Bundles a CF-Pages-ready directory:
```
dist/
  index.html      # workload description + per-property summary + iframe(report.html)
  report.html     # output of `etna experiment report`
  report.json     # same metrics payload, exposed for /json
  store.jsonl     # verbatim per-trial rows
  etna.toml       # copy of the workload manifest
```

### 3. Reusable workflow `.github/workflows/run-and-publish.yml`
Callable from any workload's repo. Inputs: strategy, trials, timeout, cf-pages-project, etna-version. Detects language from `etna.toml` and bootstraps the right toolchain (rust / haskell / ocaml / rocq / lean) with appropriate caches, installs etna-cli from a release, runs the experiment, calls `publish-page`, and deploys via `cloudflare/wrangler-action`.

Per-workload caller is 5 lines:
```yaml
jobs:
  publish:
    uses: alpaylan/etna-cli/.github/workflows/run-and-publish.yml@vX.Y.Z
    with: { strategy: plausible, trials: 20 }
    secrets:
      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
```

## Refactor
`render_html` now goes through a `ReportPayload` struct so HTML and JSON sinks share the exact same data without re-reading the store twice.

## Test plan
- [x] `cargo build --release` clean (no new warnings)
- [x] `etna experiment report --json-output /tmp/r.json` against an existing experiment — JSON parses, contains `experiment` / `generated_at` / `workload_docs` / `metrics`
- [x] `etna experiment publish-page --output /tmp/dist` against the same experiment — emits 5 files; `index.html` opens locally; summary table shows 49 passed / 41 failed across 9 cedar-lean properties
- [ ] After merge: tag v0.1.10, then add a `publish.yml` caller to alpaylan/cedar-etna and watch the live deploy at https://cedar-etna.pages.dev