### PR TITLE
release(0.1.10): bump version for publish-page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "etna"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "ab_glyph",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["workloads/Test/harness"]
 
 [package]
 name = "etna"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 default-run = "etna"
 repository = "https://github.com/alpaylan/etna-cli"


### PR DESCRIPTION
Bumps Cargo.toml 0.1.9 → 0.1.10 so the release pipeline ships the
`etna experiment publish-page` subcommand and the
`.github/workflows/run-and-publish.yml` reusable workflow added in #25.

After this merges, please tag v0.1.10 to trigger the dist release.

Once tagged, every workload's caller can pin to:
```yaml
uses: alpaylan/etna-cli/.github/workflows/run-and-publish.yml@v0.1.10
```