### PR TITLE
fix(workflow): run etna setup before workload add

### DIFF
--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -167,11 +167,14 @@ jobs:
           "$HOME/.cargo/bin/etna" --version || true
 
       # ---------- Set up experiment + workload --------------------------
+      # `etna setup` initialises ~/.etna/config.json (non-interactive) so
+      # subsequent commands have a valid config to read.
       # `etna workload add` clones from a git URL. We pass the current repo's
       # URL + SHA so the workload mirrors what's in CI exactly.
       - name: Create experiment + add workload
         shell: bash
         run: |
+          etna setup --overwrite || true
           mkdir -p /tmp/etna-experiment
           cd /tmp/etna-experiment
           etna experiment new ci-run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "etna"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "ab_glyph",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["workloads/Test/harness"]
 
 [package]
 name = "etna"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 default-run = "etna"
 repository = "https://github.com/alpaylan/etna-cli"


### PR DESCRIPTION
First canary run on cedar-etna failed at the very first `etna` command:

```
Error: All commands other than `etna setup` require a valid configuration,
please make sure you ran `etna setup` first (at src/cli.rs:146)
```

Hosted runners are fresh — `~/.etna/config.json` doesn't exist until
`etna setup` runs.

## Bundled in this PR
- Add `etna setup --overwrite` before `etna experiment new` in the reusable workflow
- Bump Cargo.toml 0.1.10 → 0.1.11 so the next tag ships the fix together

## After merge
Tag v0.1.11 and the cedar-etna canary will succeed once its caller is
retargeted from `@v0.1.10` to `@v0.1.11`.

Reference run: https://github.com/alpaylan/cedar-etna/actions/runs/25091247939