### PR TITLE
manifest: require strategies + canary CI fixes

### DIFF
--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -211,15 +211,19 @@ jobs:
         if: steps.meta.outputs.language == 'rocq' || steps.meta.outputs.language == 'coq'
         shell: bash
         run: |
-          # Pin Coq + QuickChick to versions known to coexist on opam's
-          # coq-released repo. Coq 8.18 + QuickChick 2.0.x avoids the
-          # rocq-elpi.3.2.0 elpi_plugin.cmxs build break that 8.20 + latest
-          # QuickChick triggers (failure was: missing
-          # _opam/.opam-switch/build/rocq-elpi.3.2.0/.../elpi_plugin.cmxs
-          # because rocq-elpi assumed dune was building artefacts under
-          # _build/install/default which the upstream package layout
-          # changed in 3.2.0).
-          opam install -y coq.8.18.0 coq-quickchick.2.0.4 coq-ext-lib
+          # Two-step install: coq.8.18.0 first so `coqc` lands on PATH
+          # *before* opam tries to build packages that shell out to it at
+          # build time (rocq-hierarchy-builder.1.9.1's Makefile invokes
+          # `rocq makefile` which calls coqc; that package mis-declares its
+          # build deps and fails with `coqc: not found` if coq isn't yet
+          # installed in the same `opam install` call).
+          #
+          # Coq 8.18 picked over 8.20 because 8.20 + coq-quickchick 2.0.x
+          # pulls rocq-elpi.3.2.0 which has a broken dune layout (missing
+          # _opam/.opam-switch/build/rocq-elpi.3.2.0/.../elpi_plugin.cmxs).
+          opam install -y coq.8.18.0
+          eval $(opam env)
+          opam install -y coq-quickchick.2.0.4 coq-ext-lib
           echo "OPAMSWITCH=$(opam switch show --safe)" >> "$GITHUB_ENV"
           echo "$(opam var prefix)/bin" >> "$GITHUB_PATH"
       - name: Cache Coq opam switch

--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -172,6 +172,16 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: '5.x'
+      # `ocaml/setup-ocaml@v3` sets up opam + appends opam-env to GITHUB_ENV,
+      # but does NOT install `dune` globally — workload steps.json setup_steps
+      # call `dune --version` directly (no `opam exec --` wrapper) so dune
+      # must be on PATH for plain bash. Install it via opam now.
+      - name: Install dune for OCaml workload
+        if: steps.meta.outputs.language == 'ocaml'
+        shell: bash
+        run: |
+          opam install -y dune
+          echo "$(opam var prefix)/bin" >> "$GITHUB_PATH"
       - name: Cache OCaml build artefacts
         if: steps.meta.outputs.language == 'ocaml'
         uses: actions/cache@v4
@@ -181,12 +191,33 @@ jobs:
           key: ${{ runner.os }}-ocaml-${{ steps.meta.outputs.name }}-${{ hashFiles('**/dune-project', '**/*.opam') }}
           restore-keys: ${{ runner.os }}-ocaml-${{ steps.meta.outputs.name }}-
 
-      - name: Setup Coq (Rocq)
+      # Coq (Rocq) install on the host. We need coqc + QuickChick + ExtLib on
+      # the host PATH because etna-cli's check/build commands (`coqc
+      # --print-version`, `${workload_path}/build`) run via std::process::Command
+      # outside any container — the previous docker-coq-action only made the
+      # binaries available inside its container.
+      - name: Setup OCaml for Coq via opam
         if: steps.meta.outputs.language == 'rocq' || steps.meta.outputs.language == 'coq'
-        uses: coq-community/docker-coq-action@v1
+        uses: ocaml/setup-ocaml@v3
         with:
-          custom_image: 'coqorg/coq:8.20'
-          custom_script: 'echo "Coq image pre-pulled"'
+          ocaml-compiler: '4.14.x'
+          opam-repositories: |
+            default: https://opam.ocaml.org
+            coq-released: https://coq.inria.fr/opam/released
+      - name: Install Coq + QuickChick + ExtLib
+        if: steps.meta.outputs.language == 'rocq' || steps.meta.outputs.language == 'coq'
+        shell: bash
+        run: |
+          opam install -y coq.8.20.0 coq-quickchick coq-ext-lib
+          echo "$(opam var prefix)/bin" >> "$GITHUB_PATH"
+      - name: Cache Coq opam switch
+        if: steps.meta.outputs.language == 'rocq' || steps.meta.outputs.language == 'coq'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.opam
+          key: ${{ runner.os }}-coq-${{ steps.meta.outputs.name }}-820
+          restore-keys: ${{ runner.os }}-coq-${{ steps.meta.outputs.name }}-
 
       - name: Install elan (Lean toolchain)
         if: steps.meta.outputs.language == 'lean'

--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -102,7 +102,9 @@ jobs:
         uses: haskell-actions/setup@v2
         with:
           enable-stack: true
-          stack-version: latest
+          # Don't pin stack-version: 'latest' resolves to a non-cached release
+          # on the runner image and forces a download that fails. Default
+          # works.
       - name: Cache Stack
         if: steps.meta.outputs.language == 'haskell'
         uses: actions/cache@v4
@@ -179,7 +181,11 @@ jobs:
           cd /tmp/etna-experiment
           etna experiment new ci-run
           cd ci-run
-          etna workload add "https://github.com/${{ github.repository }}.git" --ref "${{ github.sha }}"
+          # Note: --ref ${{ github.sha }} is correct intent but `etna workload add`
+          # passes that to `git clone --branch` which doesn't accept SHAs (alpaylan/etna-cli#28).
+          # Falling back to the default branch — fine for push-to-main triggers
+          # since the default-branch HEAD == github.sha.
+          etna workload add "https://github.com/${{ github.repository }}.git"
           ls tests/
 
       - name: Amend test with strategy

--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -99,9 +99,30 @@ jobs:
           echo "Detected workload: name=$name language=$language"
 
       # ---------- Per-language toolchain bootstrap + cache --------------
+      # Rust toolchain channel: read from rust-toolchain.toml or rust-toolchain
+      # if present, otherwise default to stable. Workloads that use unstable
+      # features (e.g. etna-rust-bst's box_patterns mutation) ship a
+      # rust-toolchain.toml pinning nightly.
+      - name: Detect Rust channel
+        if: steps.meta.outputs.language == 'rust'
+        id: rust_channel
+        shell: bash
+        run: |
+          channel="stable"
+          if [ -f rust-toolchain.toml ]; then
+            val=$(grep -E '^channel *= *' rust-toolchain.toml | head -1 | sed -E 's/.*= *"([^"]*)".*/\1/')
+            [ -n "$val" ] && channel="$val"
+          elif [ -f rust-toolchain ]; then
+            val=$(tr -d '[:space:]' < rust-toolchain)
+            [ -n "$val" ] && channel="$val"
+          fi
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          echo "Rust channel: $channel"
       - name: Setup Rust
         if: steps.meta.outputs.language == 'rust'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust_channel.outputs.channel }}
       - name: Cache Rust
         if: steps.meta.outputs.language == 'rust'
         uses: actions/cache@v4

--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -177,6 +177,13 @@ jobs:
         shell: bash
         run: |
           opam install -y dune
+          # ocaml/setup-ocaml@v3 creates a workspace-local _opam switch but
+          # doesn't export OPAMSWITCH. etna-cli's driver later runs
+          # `opam exec -- dune build` from /tmp/etna-experiment/.../bst-ocaml
+          # which is outside the workspace tree, so opam's cwd-walk can't
+          # find _opam. Pin OPAMSWITCH to the absolute switch path so opam
+          # picks it up no matter where it's invoked.
+          echo "OPAMSWITCH=$(opam switch show --safe)" >> "$GITHUB_ENV"
           echo "$(opam var prefix)/bin" >> "$GITHUB_PATH"
       - name: Cache OCaml build artefacts
         if: steps.meta.outputs.language == 'ocaml'
@@ -204,7 +211,16 @@ jobs:
         if: steps.meta.outputs.language == 'rocq' || steps.meta.outputs.language == 'coq'
         shell: bash
         run: |
-          opam install -y coq.8.20.0 coq-quickchick coq-ext-lib
+          # Pin Coq + QuickChick to versions known to coexist on opam's
+          # coq-released repo. Coq 8.18 + QuickChick 2.0.x avoids the
+          # rocq-elpi.3.2.0 elpi_plugin.cmxs build break that 8.20 + latest
+          # QuickChick triggers (failure was: missing
+          # _opam/.opam-switch/build/rocq-elpi.3.2.0/.../elpi_plugin.cmxs
+          # because rocq-elpi assumed dune was building artefacts under
+          # _build/install/default which the upstream package layout
+          # changed in 3.2.0).
+          opam install -y coq.8.18.0 coq-quickchick.2.0.4 coq-ext-lib
+          echo "OPAMSWITCH=$(opam switch show --safe)" >> "$GITHUB_ENV"
           echo "$(opam var prefix)/bin" >> "$GITHUB_PATH"
       - name: Cache Coq opam switch
         if: steps.meta.outputs.language == 'rocq' || steps.meta.outputs.language == 'coq'

--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -97,6 +97,17 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ steps.meta.outputs.name }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-${{ steps.meta.outputs.name }}-
 
+      # Pre-build manually so the compile diagnostic surfaces here. etna-cli's
+      # `build_steps` driver captures stdout/stderr via `cmd.output()` and on
+      # failure only prints `[✗] cargo build --release failed` — the actual
+      # compile error is dropped on the floor (alpaylan/etna-cli build_steps
+      # output buffering). Running cargo here means a later `etna experiment
+      # run` no-ops the build (already cached).
+      - name: Pre-build Rust workload (visible diagnostics)
+        if: steps.meta.outputs.language == 'rust'
+        shell: bash
+        run: cargo build --release
+
       - name: Setup Haskell + Stack
         if: steps.meta.outputs.language == 'haskell'
         uses: haskell-actions/setup@v2

--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -13,10 +13,6 @@ name: Run experiment and publish to Cloudflare Pages
 on:
   workflow_call:
     inputs:
-      strategy:
-        description: 'Strategy to amend onto every task (e.g. plausible, etna, proptest)'
-        type: string
-        default: plausible
       trials:
         description: 'Trials per (variant, property)'
         type: number
@@ -271,14 +267,10 @@ jobs:
           etna workload add "https://github.com/${{ github.repository }}.git"
           ls tests/
 
-      - name: Amend test with strategy
-        shell: bash
-        run: |
-          cd /tmp/etna-experiment/ci-run
-          test_name="${{ steps.meta.outputs.name }}"
-          etna experiment amend-test --test "$test_name" --strategy "${{ inputs.strategy }}"
-
       # ---------- Run + publish ----------------------------------------
+      # Strategies are seeded into tests/<name>.json from etna.toml's
+      # `strategies = [...]` field at workload-add time — no amend-test step
+      # needed.
       - name: Run experiment
         shell: bash
         run: |

--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -211,17 +211,25 @@ jobs:
         if: steps.meta.outputs.language == 'rocq' || steps.meta.outputs.language == 'coq'
         shell: bash
         run: |
-          # Two-step install: coq.8.18.0 first so `coqc` lands on PATH
-          # *before* opam tries to build packages that shell out to it at
-          # build time (rocq-hierarchy-builder.1.9.1's Makefile invokes
-          # `rocq makefile` which calls coqc; that package mis-declares its
-          # build deps and fails with `coqc: not found` if coq isn't yet
-          # installed in the same `opam install` call).
+          # Three-step install — opam's solver picks a build order that's
+          # broken on coq-released for our target versions, so force the
+          # ordering by hand:
+          #   1. coq.8.18.0 (puts coqc on PATH)
+          #   2. coq-elpi (puts the elpi loader on the coq loadpath)
+          #   3. coq-quickchick + coq-ext-lib (need both 1 and 2 at build
+          #      time: rocq-hierarchy-builder.1.9.1's Makefile imports
+          #      `elpi` and `elpi.apps.locker` from the loadpath but
+          #      doesn't declare coq-elpi as a build dep, so a single-call
+          #      `opam install` builds HB before elpi and the build fails
+          #      with `library elpi is required from root elpi and has not
+          #      been found in the loadpath`).
           #
           # Coq 8.18 picked over 8.20 because 8.20 + coq-quickchick 2.0.x
           # pulls rocq-elpi.3.2.0 which has a broken dune layout (missing
           # _opam/.opam-switch/build/rocq-elpi.3.2.0/.../elpi_plugin.cmxs).
           opam install -y coq.8.18.0
+          eval $(opam env)
+          opam install -y coq-elpi
           eval $(opam env)
           opam install -y coq-quickchick.2.0.4 coq-ext-lib
           echo "OPAMSWITCH=$(opam switch show --safe)" >> "$GITHUB_ENV"

--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -57,6 +57,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0   # marauders applies patches; full history avoids surprise reset behaviour
+          # Submodules are inited later, after the SSH→HTTPS URL rewrite, so
+          # this step doesn't fail on workloads whose `.gitmodules` uses
+          # `git@github.com:` URLs (which have no key on hosted runners).
+
+      # Workloads with submodules (e.g. etna-haskell-bst → etna-haskell-lib)
+      # ship `.gitmodules` entries with `git@github.com:` URLs. Rewrite to
+      # HTTPS once globally so any subsequent `git submodule …` works without
+      # SSH keys, then init the submodules ourselves.
+      - name: Init submodules over HTTPS
+        shell: bash
+        run: |
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          if [ -f .gitmodules ]; then
+            git submodule sync --recursive
+            git submodule update --init --recursive
+          fi
 
       # ---------- Read workload metadata --------------------------------
       - name: Detect language from etna.toml
@@ -113,9 +129,13 @@ jobs:
         uses: haskell-actions/setup@v2
         with:
           enable-stack: true
-          # Don't pin stack-version: 'latest' resolves to a non-cached release
-          # on the runner image and forces a download that fails. Default
-          # works.
+          # Pin to a stack version known to be pre-cached on
+          # actions/runner-images ubuntu-latest. Defaulting to 'latest'
+          # routes through GHCup which has been flaky resolving the
+          # newest 3.x release on hosted runners.
+          stack-version: '2.15.7'
+          # The build_steps for haskell workloads use `--no-system-ghc`
+          # so stack downloads its own GHC; we don't pin ghc-version here.
       - name: Cache Stack
         if: steps.meta.outputs.language == 'haskell'
         uses: actions/cache@v4

--- a/src/commands/experiment/visualize.rs
+++ b/src/commands/experiment/visualize.rs
@@ -310,18 +310,20 @@ fn get_agg_metrics(
 
             if let Some(timeout) = timed_out {
                 tracing::warn!("Some metrics in group {:?} timed out", agg);
-                let data = serde_json::json!({
-                    "language": agg[0],
-                    "workload": agg[1],
-                    "strategy": agg[2],
-                    "property": agg[3],
-                    "mutations": agg[4],
-                    "mode": agg[5],
-                    "discards": f64::NAN,
-                    "tests": f64::NAN,
-                    "shrinks": f64::NAN,
-                    "time": format!("{timeout}s"),
-                });
+                let mut data = serde_json::Map::new();
+                for (i, key) in aggby.iter().enumerate() {
+                    if let Some(v) = agg.get(i) {
+                        data.insert(key.clone(), (*v).clone());
+                    }
+                }
+                data.insert("discards".to_string(), serde_json::Value::from(f64::NAN));
+                data.insert("tests".to_string(), serde_json::Value::from(f64::NAN));
+                data.insert("shrinks".to_string(), serde_json::Value::from(f64::NAN));
+                data.insert(
+                    "time".to_string(),
+                    serde_json::Value::from(format!("{timeout}s")),
+                );
+                let data = serde_json::Value::Object(data);
                 tracing::trace!("Returning timeout data: {:#?}", data);
                 let _ = write_row(&mut raw_data_file, &data, aggby);
                 return data.as_object().cloned();
@@ -343,18 +345,17 @@ fn get_agg_metrics(
 
             if let Some(true) = aborted {
                 tracing::error!("Some metrics in group {:?} were aborted", agg);
-                let data = serde_json::json!({
-                    "language": agg[0],
-                    "workload": agg[1],
-                    "strategy": agg[2],
-                    "property": agg[3],
-                    "mutations": agg[4],
-                    "mode": agg[5],
-                    "discards": f64::NAN,
-                    "tests": f64::NAN,
-                    "shrinks": f64::NAN,
-                    "time": f64::NAN,
-                });
+                let mut data = serde_json::Map::new();
+                for (i, key) in aggby.iter().enumerate() {
+                    if let Some(v) = agg.get(i) {
+                        data.insert(key.clone(), (*v).clone());
+                    }
+                }
+                data.insert("discards".to_string(), serde_json::Value::from(f64::NAN));
+                data.insert("tests".to_string(), serde_json::Value::from(f64::NAN));
+                data.insert("shrinks".to_string(), serde_json::Value::from(f64::NAN));
+                data.insert("time".to_string(), serde_json::Value::from(f64::NAN));
+                let data = serde_json::Value::Object(data);
                 tracing::trace!("Returning aborted data: {:#?}", data);
                 let _ = write_row(&mut raw_data_file, &data, aggby);
                 return data.as_object().cloned();
@@ -460,18 +461,24 @@ fn get_agg_metrics(
                 avgs.3
             );
 
-            let data = serde_json::json!({
-                "language": agg[0],
-                "workload": agg[1],
-                "strategy": agg[2],
-                "property": agg[3],
-                "mutations": agg[4],
-                "cross": agg[5],
-                "discards": avgs.0,
-                "tests": avgs.1,
-                "shrinks": avgs.2,
-                "time": avgs.3,
-            });
+            // Build the row dynamically from aggby — its ordering can vary
+            // (default is workload/strategy/property/mutations/mode; not every
+            // call specifies "cross" or "language") so a hard-coded index map
+            // panics for any aggby shorter than 6 entries.
+            let mut data = serde_json::Map::new();
+            for (i, key) in aggby.iter().enumerate() {
+                if let Some(v) = agg.get(i) {
+                    data.insert(key.clone(), (*v).clone());
+                }
+            }
+            data.insert(
+                "discards".to_string(),
+                serde_json::Value::from(avgs.0),
+            );
+            data.insert("tests".to_string(), serde_json::Value::from(avgs.1));
+            data.insert("shrinks".to_string(), serde_json::Value::from(avgs.2));
+            data.insert("time".to_string(), serde_json::Value::from(avgs.3));
+            let data = serde_json::Value::Object(data);
             tracing::debug!("Writing to {}: {:#?}", raw_data_path.display(), data);
             let _ = write_row(&mut raw_data_file, &data, aggby);
 

--- a/src/service/experiment.rs
+++ b/src/service/experiment.rs
@@ -648,7 +648,7 @@ pub fn create_test(
     })?;
 
     let manifest = crate::workload::WorkloadManifest::read(&workload_path)?;
-    let mut tests = super::workload::tests_from_manifest(&manifest);
+    let mut tests = super::workload::tests_from_manifest(&manifest)?;
 
     // Override the manifest-seeded defaults with caller-supplied trial/timeout/mode.
     for test in tests.iter_mut() {

--- a/src/service/site.rs
+++ b/src/service/site.rs
@@ -327,6 +327,7 @@ mod tests {
         let manifest = r#"
 name = "x"
 language = "rust"
+strategies = ["proptest"]
 
 [[tasks]]
 mutations = ["m_0000000_1"]
@@ -381,6 +382,7 @@ property = "SomeProp"
         let manifest = r#"
 name = "cratefork"
 language = "rust"
+strategies = ["proptest"]
 
 [[tasks]]
 mutations = ["m_0000000_1"]

--- a/src/service/workload.rs
+++ b/src/service/workload.rs
@@ -61,10 +61,19 @@ const DEFAULT_TRIALS: usize = 10;
 const DEFAULT_TIMEOUT: f64 = 60.0;
 
 /// Build `Test` entries from a workload's `etna.toml` manifest. Each
-/// `[[tasks]]` block becomes one `Test` keyed by its mutation subset. Returns
-/// an empty vec when the manifest has no `[[tasks]]` blocks.
-pub(crate) fn tests_from_manifest(manifest: &WorkloadManifest) -> Vec<Test> {
-    manifest
+/// `[[tasks]]` block becomes one `Test` keyed by its mutation subset; each
+/// (property × strategy) pair inside the block becomes one task in the
+/// emitted `Test`. Errors when `manifest.strategies` is empty — every
+/// runnable workload must declare at least one strategy name.
+pub(crate) fn tests_from_manifest(manifest: &WorkloadManifest) -> anyhow::Result<Vec<Test>> {
+    if manifest.strategies.is_empty() {
+        bail!(
+            "Workload '{}' has no strategies declared in etna.toml. Add a top-level `strategies = [...]` listing the strategy names the workload's runner dispatches on.",
+            manifest.name
+        );
+    }
+
+    Ok(manifest
         .tasks
         .iter()
         .map(|group| Test {
@@ -77,31 +86,37 @@ pub(crate) fn tests_from_manifest(manifest: &WorkloadManifest) -> Vec<Test> {
             tasks: group
                 .tasks
                 .iter()
-                .map(|task| {
-                    let mut map = HashMap::new();
-                    map.insert(
-                        "property".to_string(),
-                        serde_json::Value::String(task.property.clone()),
-                    );
-                    if !task.witnesses.is_empty() {
+                .flat_map(|task| {
+                    manifest.strategies.iter().map(move |strat| {
+                        let mut map = HashMap::new();
                         map.insert(
-                            "witnesses".to_string(),
-                            serde_json::to_value(&task.witnesses)
-                                .unwrap_or(serde_json::Value::Null),
+                            "property".to_string(),
+                            serde_json::Value::String(task.property.clone()),
                         );
-                    }
-                    map
+                        map.insert(
+                            "strategy".to_string(),
+                            serde_json::Value::String(strat.clone()),
+                        );
+                        if !task.witnesses.is_empty() {
+                            map.insert(
+                                "witnesses".to_string(),
+                                serde_json::to_value(&task.witnesses)
+                                    .unwrap_or(serde_json::Value::Null),
+                            );
+                        }
+                        map
+                    })
                 })
                 .collect(),
         })
-        .collect()
+        .collect())
 }
 
 fn seed_tests_file(
     experiment: &ExperimentMetadata,
     manifest: &WorkloadManifest,
 ) -> anyhow::Result<()> {
-    let generated = tests_from_manifest(manifest);
+    let generated = tests_from_manifest(manifest)?;
     if generated.is_empty() {
         return Ok(());
     }

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -364,6 +364,13 @@ pub struct WorkloadManifest {
     pub base_commit: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tasks: Vec<ManifestTaskGroup>,
+    /// PBT strategy names this workload's runner accepts. Required —
+    /// `etna workload add` seeds one task per (property × strategy) pair, so
+    /// a missing or empty list produces no runnable tests. Each name must
+    /// match an exact identifier the workload binary's dispatcher expects
+    /// (e.g. cedar-lean: "plausible"/"etna"; haskell-bst: "Quick"/"Hedgehog";
+    /// rocq-bst: "BespokeGenerator"/"TypeBasedGenerator").
+    pub strategies: Vec<String>,
     /// Upstream fix commits that were considered for injection but rejected.
     /// Rendered in `BUGS.md` under "Dropped Candidates" for audit trail.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -514,18 +521,36 @@ mod manifest_tests {
 
     #[test]
     fn legacy_minimal_manifest_still_parses() {
-        // Fields added in the v2 extension must all be optional.
+        // Fields added in the v2 extension must all be optional except
+        // `strategies`, which became required in 0.1.12.
         let toml = r#"
             name = "example"
             language = "rust"
+            strategies = ["s1"]
         "#;
         let m: WorkloadManifest = toml::from_str(toml).expect("minimal parse");
         assert_eq!(m.name, "example");
         assert_eq!(m.language, "rust");
+        assert_eq!(m.strategies, vec!["s1"]);
         assert!(m.tasks.is_empty());
         assert!(m.dropped.is_empty());
         assert!(m.crate_name.is_none());
         assert!(m.base_commit.is_none());
+    }
+
+    #[test]
+    fn manifest_missing_strategies_is_rejected() {
+        // `strategies` is required as of 0.1.12 — surface a clear error so
+        // stale manifests fail loudly at `etna workload add` time.
+        let toml = r#"
+            name = "example"
+            language = "rust"
+        "#;
+        let err = toml::from_str::<WorkloadManifest>(toml).expect_err("must reject");
+        assert!(
+            format!("{err}").contains("missing field `strategies`"),
+            "expected missing-strategies error, got: {err}"
+        );
     }
 
     #[test]
@@ -535,6 +560,7 @@ mod manifest_tests {
         let toml = r#"
             name = "example"
             language = "rust"
+            strategies = ["s1"]
 
             [[tasks]]
             mutations = ["foo_1234567_1"]
@@ -564,6 +590,7 @@ mod manifest_tests {
             language = "rust"
             crate = "tinyvec"
             base_commit = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+            strategies = ["proptest"]
 
             [[tasks]]
             mutations = ["debug_alternate_empty_a711c72_1"]
@@ -651,6 +678,7 @@ mod manifest_tests {
         let toml = r#"
             name = "aho-corasick"
             language = "rust"
+            strategies = ["proptest"]
 
             [[tasks]]
             mutations = ["ac_patched_0000000_1"]

--- a/tests/workload_check.rs
+++ b/tests/workload_check.rs
@@ -28,6 +28,7 @@ fn load(dir: &Path) -> WorkloadManifest {
 const BASE_MANIFEST: &str = r#"
 name = "demo"
 language = "rust"
+strategies = ["demo_strategy"]
 
 [[tasks]]
 mutations = ["demo_mutation_abcdef0_1"]
@@ -112,6 +113,7 @@ fn flags_bad_variant_name() {
     let manifest_text = r#"
 name = "demo"
 language = "rust"
+strategies = ["demo_strategy"]
 
 [[tasks]]
 mutations = ["NotAVariantName"]
@@ -187,6 +189,7 @@ fn flags_missing_patch_file() {
     let manifest_text = r#"
 name = "demo"
 language = "rust"
+strategies = ["demo_strategy"]
 
 [[tasks]]
 mutations = ["demo_patch_abcdef0_1"]

--- a/workloads/Test/DocGen/empty_tasks/etna.toml
+++ b/workloads/Test/DocGen/empty_tasks/etna.toml
@@ -1,3 +1,4 @@
 name = "empty_tasks"
 description = "Generator-style workload with no injected bugs (like BST/RBT/STLC). `etna workload doc` must no-op."
 language = "rust"
+strategies = ["proptest"]

--- a/workloads/Test/DocGen/patch_injection/etna.toml
+++ b/workloads/Test/DocGen/patch_injection/etna.toml
@@ -1,5 +1,6 @@
 name = "patch_injection"
 language = "rust"
+strategies = ["proptest"]
 base_commit = "1111111111111111111111111111111111111111"
 
 [[tasks]]

--- a/workloads/Test/DocGen/tinyvec_like/etna.toml
+++ b/workloads/Test/DocGen/tinyvec_like/etna.toml
@@ -2,6 +2,7 @@ name = "tinyvec_like"
 description = "Test fixture mirroring the tinyvec injection shape: two marauders-based bugs with full source provenance."
 language = "rust"
 crate = "tinyvec"
+strategies = ["proptest"]
 base_commit = "0123456789abcdef0123456789abcdef01234567"
 
 [[tasks]]

--- a/workloads/Test/T1/etna.toml
+++ b/workloads/Test/T1/etna.toml
@@ -1,6 +1,7 @@
 name = "T1"
 description = "Integration-test fixture workload (producer side)."
 language = "Test"
+strategies = ["bespoke"]
 
 [[tasks]]
 mutations = []

--- a/workloads/Test/T2/etna.toml
+++ b/workloads/Test/T2/etna.toml
@@ -1,6 +1,7 @@
 name = "T2"
 description = "Integration-test fixture workload (consumer side)."
 language = "Test"
+strategies = ["bespoke"]
 
 [[tasks]]
 mutations = []


### PR DESCRIPTION
## Summary
Six commits accumulated on \`fix-canary-rollout\` that need to ship as v0.1.12 so the per-workload canary publish flow works end-to-end:

1. **47e5cd8** \`manifest: require strategies\` — \`WorkloadManifest.strategies: Vec<String>\` is now a required field; \`tests_from_manifest\` emits one task per (property × strategy). The reusable workflow drops its \`amend-test\` step + \`strategy\` input. Required because the previous flow (\`amend-test --strategy plausible\`) only worked for cedar-lean.
2. **401cc83** \`ci: install OCaml/Rocq toolchains on host PATH\` — replaces docker-coq-action (container-isolated) with opam install on the host so etna-cli's std::process::Command can find coqc/dune.
3. **6abd5e6** \`ci: respect rust-toolchain.toml\` — workloads requiring nightly (e.g. etna-rust-bst's box_patterns mutation) can pin the channel.
4. **659056c** \`fix: init submodules over HTTPS + pin stack to 2.15.7\` — workloads with \`git@github.com:\` submodule URLs now work on hosted runners; stack 3.x flake worked around.
5. **0eb5d16** \`fix: pre-build Rust workloads so cargo errors actually surface\` — etna-cli's build_steps swallow stderr; pre-build outside the driver makes failures debuggable.
6. **c03cd32** \`fix: drop --ref from etna workload add\` — git clone --branch doesn't accept SHAs (issue #28).

Plus a pre-existing visualize.rs panic fix (\`agg[5]\` index hardcoded).

The 5 per-language canaries already have matching PRs merged (cedar-etna#2, etna-haskell-bst#3, etna-rocq-bst#1, etna-rust-bst#2, etna-ocaml-bst#1) declaring \`strategies = [...]\` in their etna.toml. They're failing in CI because \`@latest\` resolves to v0.1.11 — they need this branch shipped as v0.1.12 first.

## Test plan
- [x] \`cargo test --release\` clean (25 pass on the new branch).
- [x] cedar-etna canary triggered against this branch's reusable workflow — green.
- [ ] After merge, tag v0.1.12 and retrigger all 5 canaries.