### PR TITLE
release(0.1.12): bump for strategies + canary CI fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "etna"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "ab_glyph",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["workloads/Test/harness"]
 
 [package]
 name = "etna"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 default-run = "etna"
 repository = "https://github.com/alpaylan/etna-cli"


### PR DESCRIPTION
## Summary
Bump etna 0.1.11 → 0.1.12 to release the strategies-required schema + workflow fixes that the canary publish flow needs.

Once merged, push tag \`v0.1.12\` so cargo-dist publishes the release artefacts and the canaries' \`@latest\` installer URL serves the new build.

## Test plan
- [x] \`cargo test --release\` clean.
- [ ] After tag, retrigger all 6 canaries (cedar-etna / haskell-bst / rust-bst / ocaml-bst / rocq-bst / half-etna).