### PR TITLE
ci(ocaml): install workload deps via opam install . --deps-only

### DIFF
--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -172,11 +172,15 @@ jobs:
       # but does NOT install `dune` globally — workload steps.json setup_steps
       # call `dune --version` directly (no `opam exec --` wrapper) so dune
       # must be on PATH for plain bash. Install it via opam now.
-      - name: Install dune for OCaml workload
+      - name: Install OCaml workload deps
         if: steps.meta.outputs.language == 'ocaml'
         shell: bash
         run: |
-          opam install -y dune
+          # ocaml/setup-ocaml@v3 finds BST.opam (or any *.opam at the repo
+          # root) but does NOT auto-install its deps. Run `opam install .
+          # --deps-only` so qcheck / crowbar / cmdliner / dune end up on the
+          # switch before etna-cli's driver tries to build the workload.
+          opam install -y . --deps-only --with-test
           # ocaml/setup-ocaml@v3 creates a workspace-local _opam switch but
           # doesn't export OPAMSWITCH. etna-cli's driver later runs
           # `opam exec -- dune build` from /tmp/etna-experiment/.../bst-ocaml


### PR DESCRIPTION
## Summary
\`opam install -y dune\` only installed dune; the workload's BST.opam declares qcheck/crowbar/cmdliner as deps but they weren't getting installed, so \`opam exec -- dune build\` failed with \"Library qcheck not found\".

Switch to \`opam install . --deps-only --with-test\` so every dep from the workload's *.opam lands on the switch.

## Test plan
- [ ] Manual workflow_dispatch on etna-ocaml-bst after merge.