### PR TITLE
ci(rocq+all): invalidate poisoned coq cache + pass --short-circuit

### DIFF
--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -276,8 +276,13 @@ jobs:
         with:
           path: |
             ~/.opam
-          key: ${{ runner.os }}-coq-${{ steps.meta.outputs.name }}-820
-          restore-keys: ${{ runner.os }}-coq-${{ steps.meta.outputs.name }}-
+          # v2 invalidates poisoned cache: an earlier failed
+          # coq-quickchick build left `_opam/.opam-switch/build/
+          # coq-quickchick.dev/plugin/depDriver.ml` on disk; subsequent
+          # runs restored that file alongside the cppo rule, dune saw
+          # "Multiple rules generated for ..._build/.../depDriver.ml".
+          key: ${{ runner.os }}-coq-${{ steps.meta.outputs.name }}-820-v2
+          restore-keys: ${{ runner.os }}-coq-${{ steps.meta.outputs.name }}-820-v2
 
       - name: Install elan (Lean toolchain)
         if: steps.meta.outputs.language == 'lean'

--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -347,19 +347,6 @@ jobs:
           du -sh "$GITHUB_WORKSPACE/dist"
           du -h "$GITHUB_WORKSPACE/dist"/*
 
-      # ---------- DIAGNOSTIC (non-credential): verify that gh-set test
-      # secrets round-trip with the expected length. The TEST_LENGTH_VALUE
-      # secret was set locally to a known 32-char ASCII string. If
-      # ${#TEST_LENGTH_VALUE} is anything other than 32 here, gh secret
-      # set is appending bytes to the value it sends GitHub.
-      - name: Debug — round-trip test of gh-set secret
-        if: ${{ secrets.TEST_LENGTH_VALUE != '' }}
-        shell: bash
-        env:
-          T: ${{ secrets.TEST_LENGTH_VALUE }}
-        run: |
-          printf 'TEST_LENGTH_VALUE length: %d (set locally to 32)\n' "${#T}"
-
       # ---------- Cloudflare Pages -------------------------------------
       # Wrangler's `pages deploy` does NOT auto-create the project — it
       # errors when the name is unknown. Create it first; ignore failures

--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -345,7 +345,7 @@ jobs:
         run: |
           cd /tmp/etna-experiment/ci-run
           test_name="${{ steps.meta.outputs.name }}"
-          etna experiment run --tests "$test_name" \
+          etna experiment run --tests "$test_name" --short-circuit \
             --params trials=${{ inputs.trials }} \
             --params timeout=${{ inputs.timeout }}
 

--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -347,6 +347,19 @@ jobs:
           du -sh "$GITHUB_WORKSPACE/dist"
           du -h "$GITHUB_WORKSPACE/dist"/*
 
+      # ---------- DIAGNOSTIC (non-credential): verify that gh-set test
+      # secrets round-trip with the expected length. The TEST_LENGTH_VALUE
+      # secret was set locally to a known 32-char ASCII string. If
+      # ${#TEST_LENGTH_VALUE} is anything other than 32 here, gh secret
+      # set is appending bytes to the value it sends GitHub.
+      - name: Debug — round-trip test of gh-set secret
+        if: ${{ secrets.TEST_LENGTH_VALUE != '' }}
+        shell: bash
+        env:
+          T: ${{ secrets.TEST_LENGTH_VALUE }}
+        run: |
+          printf 'TEST_LENGTH_VALUE length: %d (set locally to 32)\n' "${#T}"
+
       # ---------- Cloudflare Pages -------------------------------------
       # Wrangler's `pages deploy` does NOT auto-create the project — it
       # errors when the name is unknown. Create it first; ignore failures

--- a/scripts/set-cf-secrets-on-workloads.sh
+++ b/scripts/set-cf-secrets-on-workloads.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Bulk: set the two Cloudflare secrets every workload's etna-publish.yml
+# expects on every stable workload listed in `docs/workloads/index.json`.
+#
+# Idempotent — overwrites existing secrets with the same values.
+#
+# Usage:
+#   scripts/set-cf-secrets-on-workloads.sh \
+#     --token-stdin \
+#     --account-id <account-id> \
+#     [--dry-run] [--limit N]
+#
+# Examples:
+#   # paste the token securely from stdin (no shell history)
+#   echo -n "$CLOUDFLARE_TOKEN" | scripts/set-cf-secrets-on-workloads.sh \
+#     --token-stdin --account-id abcdef123
+#
+#   # dry-run to see which repos would get touched
+#   scripts/set-cf-secrets-on-workloads.sh --token-stdin --account-id x --dry-run
+#
+# Required env:
+#   GH_TOKEN with `repo` scope (or `gh auth login`).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INDEX_JSON="$SCRIPT_DIR/../docs/workloads/index.json"
+
+TOKEN=""
+ACCOUNT_ID=""
+DRY_RUN=0
+LIMIT=999
+TOKEN_FROM_STDIN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --token)        TOKEN="$2"; shift 2 ;;
+    --token-stdin)  TOKEN_FROM_STDIN=1; shift ;;
+    --account-id)   ACCOUNT_ID="$2"; shift 2 ;;
+    --dry-run)      DRY_RUN=1; shift ;;
+    --limit)        LIMIT="$2"; shift 2 ;;
+    -h|--help)      sed -n '2,21p' "$0"; exit 0 ;;
+    *)              echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ "$TOKEN_FROM_STDIN" -eq 1 ]; then
+  TOKEN="$(cat)"
+fi
+
+if [ -z "$TOKEN" ] || [ -z "$ACCOUNT_ID" ]; then
+  echo "[secrets] error: --token (or --token-stdin) and --account-id are required" >&2
+  exit 1
+fi
+
+if [ ! -f "$INDEX_JSON" ]; then
+  echo "[secrets] error: index.json not found at $INDEX_JSON" >&2
+  exit 1
+fi
+
+# Iterate stable, non-wip entries.
+mapfile -t ENTRIES < <(
+  python3 - <<PY
+import json
+data = json.load(open("$INDEX_JSON"))
+for e in data["entries"]:
+    if e.get("status") != "stable":
+        continue
+    if "wip" in e.get("tags", []):
+        continue
+    print(f"{e['name']}\t{e['url']}")
+PY
+)
+
+count=0
+ok=0
+fail=0
+for entry in "${ENTRIES[@]}"; do
+  count=$((count + 1))
+  if [ "$count" -gt "$LIMIT" ]; then break; fi
+
+  name="${entry%%$'\t'*}"
+  url="${entry##*$'\t'}"
+  owner_repo="${url#https://github.com/}"
+  owner_repo="${owner_repo%.git}"
+
+  echo "[secrets] [$count] $name -> $owner_repo"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "[secrets]   (dry-run) would set CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID"
+    continue
+  fi
+
+  if ! gh repo view "$owner_repo" >/dev/null 2>&1; then
+    echo "[secrets]   repo not accessible (deleted or private?), skipping"
+    fail=$((fail + 1))
+    continue
+  fi
+
+  # NB: must use `--body "<string>"`, NOT `--body -` with piped stdin.
+  # gh CLI 2.88.1 (and probably nearby versions) silently truncates the
+  # stdin form to the first character — empirically confirmed by setting
+  # a 32-char known string and reading `${#SECRET}` inside an Actions run.
+  if gh secret set CLOUDFLARE_API_TOKEN  --repo "$owner_repo" --body "$TOKEN"      >/dev/null 2>&1 \
+     && gh secret set CLOUDFLARE_ACCOUNT_ID --repo "$owner_repo" --body "$ACCOUNT_ID" >/dev/null 2>&1; then
+    echo "[secrets]   ok"
+    ok=$((ok + 1))
+  else
+    echo "[secrets]   secret set failed (auth scope? repo permissions?)"
+    fail=$((fail + 1))
+  fi
+done
+
+echo
+echo "[secrets] done — $ok ok, $fail fail, $count total"


### PR DESCRIPTION
Two CI tweaks:

1. **Invalidate poisoned coq opam cache (v1 → v2)**: \`actions/cache@v4\` restored \`~/.opam\` from a previous failed coq-quickchick build that left \`_opam/.opam-switch/build/coq-quickchick.dev/plugin/depDriver.ml\` on disk. Subsequent runs hit "Multiple rules generated for ...depDriver.ml: file present in source tree, plugin/dune:31".

2. **\`etna experiment run --short-circuit\`**: stops trials at the first failing case per test instead of running the full trials × timeout budget. Cuts canary wall time from ~30+ min to a few minutes on the slow languages (Haskell stack, OCaml dune).