### PR TITLE
ci: auto-set GitHub repo homepage to deployed Pages URL

### DIFF
--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -47,6 +47,9 @@ jobs:
     permissions:
       contents: read
       deployments: write
+      # `Set GitHub repo homepage` step below uses gh API
+      # PATCH /repos/{owner}/{repo} which requires administration write.
+      administration: write
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -391,3 +394,17 @@ jobs:
         run: |
           echo "Deployed to https://${{ steps.meta.outputs.project }}.pages.dev/"
           echo "JSON endpoint: https://${{ steps.meta.outputs.project }}.pages.dev/report.json"
+
+      # Auto-set the GitHub repo "Website" field so the published URL
+      # surfaces in the repo header next to the description. Idempotent
+      # — if the homepage already matches, the API call is a no-op.
+      # `continue-on-error` because losing this isn't worth failing
+      # the canary over.
+      - name: Set GitHub repo homepage to deployed URL
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          url="https://${{ steps.meta.outputs.project }}.pages.dev/"
+          gh repo edit "${{ github.repository }}" --homepage "$url"


### PR DESCRIPTION
After a successful CF Pages deploy, run `gh repo edit <repo> --homepage <url>` so each canary's GitHub repo header links directly to its live results page. Idempotent. Requires `administration: write` permission on the workflow GITHUB_TOKEN.