### PR TITLE
ci: bump job timeout-minutes 90 → 360

### DIFF
--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -43,7 +43,7 @@ concurrency:
 jobs:
   run:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 360
     permissions:
       contents: read
       deployments: write


### PR DESCRIPTION
## Summary

90 min wasn't enough for haskell-bst at trials=10 / per-trial timeout=10s — every recent run got cancelled at the cap before reaching the publish step. 360 min is the GitHub Actions hard ceiling and gives every canary headroom even at full strategy sweep.

## Test plan
- [ ] Trigger workflow_dispatch on alpaylan/etna-haskell-bst
- [ ] Confirm it reaches the deploy step instead of being cancelled