### PR TITLE
ci: slugify underscores in CF Pages project name

### DIFF
--- a/.github/workflows/run-and-publish.yml
+++ b/.github/workflows/run-and-publish.yml
@@ -95,7 +95,13 @@ jobs:
             # short workload names like `half`, `bst-rust`, `bst-haskell`
             # collide with other accounts' projects and the deploy 4xx's
             # silently. Callers can still override with `cf-pages-project`.
-            echo "project=etna-$name" >> "$GITHUB_OUTPUT"
+            #
+            # CF Pages project names also disallow underscores ("Project
+            # names can be 1-58 lowercase characters with dashes" per
+            # the API), so slugify `_` → `-`. compact_str → etna-compact-str
+            # rather than etna-compact_str (invalid).
+            slug=$(echo "$name" | tr '_' '-')
+            echo "project=etna-$slug" >> "$GITHUB_OUTPUT"
           fi
           echo "Detected workload: name=$name language=$language"
 


### PR DESCRIPTION
Cloudflare Pages rejects underscores in project names. Slugify `name` (e.g. compact_str → compact-str) before prefixing `etna-`, so `etna-compact_str` becomes `etna-compact-str`. Unblocks deploys for compact_str-etna, lz4_flex-etna, toml_edit-etna.