### PR TITLE
feat(manifest): inactive=true + reason on ManifestTask

### DIFF
--- a/src/service/workload.rs
+++ b/src/service/workload.rs
@@ -86,6 +86,7 @@ pub(crate) fn tests_from_manifest(manifest: &WorkloadManifest) -> anyhow::Result
             tasks: group
                 .tasks
                 .iter()
+                .filter(|task| !task.inactive)
                 .flat_map(|task| {
                     manifest.strategies.iter().map(move |strat| {
                         let mut map = HashMap::new();
@@ -792,4 +793,85 @@ fn render_tasks_md(manifest: &WorkloadManifest) -> String {
     }
 
     buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workload::{ManifestTask, ManifestTaskGroup, WorkloadManifest};
+
+    fn manifest_with_two_tasks(t1_inactive: bool, t2_inactive: bool) -> WorkloadManifest {
+        WorkloadManifest {
+            name: "demo".to_string(),
+            description: None,
+            language: "rust".to_string(),
+            crate_name: None,
+            base_commit: None,
+            strategies: vec!["proptest".to_string(), "quickcheck".to_string()],
+            tasks: vec![ManifestTaskGroup {
+                mutations: vec!["m1".to_string()],
+                tasks: vec![
+                    ManifestTask {
+                        property: "PropA".to_string(),
+                        witnesses: vec![],
+                        inactive: t1_inactive,
+                        reason: if t1_inactive {
+                            Some("hangs runner".to_string())
+                        } else {
+                            None
+                        },
+                    },
+                    ManifestTask {
+                        property: "PropB".to_string(),
+                        witnesses: vec![],
+                        inactive: t2_inactive,
+                        reason: None,
+                    },
+                ],
+                source: None,
+                injection: None,
+                bug: None,
+            }],
+            dropped: vec![],
+        }
+    }
+
+    #[test]
+    fn tests_from_manifest_includes_active_tasks() {
+        let manifest = manifest_with_two_tasks(false, false);
+        let out = tests_from_manifest(&manifest).unwrap();
+        // 1 group × 2 tasks × 2 strategies = 4 entries
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].tasks.len(), 4);
+        let props: Vec<&str> = out[0]
+            .tasks
+            .iter()
+            .filter_map(|m| m.get("property")?.as_str())
+            .collect();
+        assert!(props.contains(&"PropA"));
+        assert!(props.contains(&"PropB"));
+    }
+
+    #[test]
+    fn tests_from_manifest_skips_inactive_tasks() {
+        let manifest = manifest_with_two_tasks(true, false);
+        let out = tests_from_manifest(&manifest).unwrap();
+        // PropA inactive → only PropB × 2 strategies = 2 entries
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].tasks.len(), 2);
+        for entry in &out[0].tasks {
+            assert_eq!(entry.get("property").and_then(|v| v.as_str()), Some("PropB"));
+        }
+    }
+
+    #[test]
+    fn tests_from_manifest_skips_all_inactive_tasks() {
+        let manifest = manifest_with_two_tasks(true, true);
+        let out = tests_from_manifest(&manifest).unwrap();
+        // Both inactive → group still emitted (its mutations may matter to
+        // downstream tooling) but with zero tasks. The runner will simply
+        // have nothing to run for this group.
+        assert_eq!(out.len(), 1);
+        assert!(out[0].tasks.is_empty());
+    }
 }

--- a/src/workload.rs
+++ b/src/workload.rs
@@ -400,6 +400,15 @@ pub struct ManifestTask {
     pub property: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub witnesses: Vec<Witness>,
+    /// When true, this (mutation × property) entry is excluded from the test
+    /// JSON emitted by `etna workload add`. The block stays in the manifest
+    /// so docs and the dashboard still surface the property + witnesses;
+    /// only the experiment runner skips it. Pair with `reason` to document
+    /// why (e.g. a buggy variant that hangs the runner).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub inactive: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 /// A known failing input. `Input` is a literal serialised value in the


### PR DESCRIPTION
## Summary

Adds optional `inactive: bool` (default false) and `reason: Option<String>` fields to `[[tasks.tasks]]` (a single property + witnesses entry inside a `[[tasks]]` group). When `inactive = true`, `tests_from_manifest` skips the entry — no test JSON is emitted for that (mutation × property × strategy) — but the block stays in the manifest so docs / dashboard / `etna workload check` all still see it.

## Why

Some workloads have buggy variants whose CI behavior makes them un-runnable today. Concrete: `toml_edit-etna/lex_close_paren_loop_cc68ae4f_1` infinite-loops the lexer on `)` inputs; the runner OOMs in ~30s, before etna's 60s per-trial timeout fires (`exit 143`). The other 5 toml_edit mutations publish fine. Granular per-task skipping lets us mark just the offending property as `inactive = true` with a `reason` instead of dropping the whole `[[tasks]]` block (which would lose source/bug/witness metadata).

## Compatibility

- `inactive` defaults to `false` and elides on serialize via `skip_serializing_if = "std::ops::Not::not"`
- `reason` defaults to `None` and elides via `skip_serializing_if = "Option::is_none"`
- All 78 stable workloads parse + serialize unchanged.

## Test plan

- [x] `cargo build --release` clean
- [x] 3 new unit tests in `service::workload::tests` (active passes through, single-inactive filters, all-inactive yields empty task list); all 3 + 26 prior unit tests pass