### PR TITLE
cli: add --store override to experiment run/visualize/report

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -179,7 +179,13 @@ pub(crate) fn run() -> anyhow::Result<()> {
             ExperimentCommand::Clone { url, path, reference } => {
                 commands::experiment::clone::invoke(mgr, url, path, reference)
             }
-            ExperimentCommand::Run { name: _, tests, short_circuit, parallel, params } => commands::experiment::run::invoke(mgr, experiment.unwrap(), tests, short_circuit, parallel, params),
+            ExperimentCommand::Run { name: _, tests, short_circuit, parallel, params, store } => {
+                let mut experiment = experiment.unwrap();
+                if let Some(path) = store {
+                    experiment.store = path;
+                }
+                commands::experiment::run::invoke(mgr, experiment, tests, short_circuit, parallel, params)
+            },
             ExperimentCommand::Show {
                         name,
                     } => commands::experiment::show::invoke(mgr, name),
@@ -205,9 +211,21 @@ pub(crate) fn run() -> anyhow::Result<()> {
                     property,
                 )
             }
-            ExperimentCommand::Visualize { name: _, figure, tests, groupby, aggby, metric, buckets, max, visualization_type, hatched } => commands::experiment::visualize::invoke(mgr, experiment.unwrap(), figure, tests, groupby, aggby, metric, buckets, max, visualization_type, hatched),
+            ExperimentCommand::Visualize { name: _, figure, tests, groupby, aggby, metric, buckets, max, visualization_type, hatched, store } => {
+                let mut experiment = experiment.unwrap();
+                if let Some(path) = store {
+                    experiment.store = path;
+                }
+                commands::experiment::visualize::invoke(mgr, experiment, figure, tests, groupby, aggby, metric, buckets, max, visualization_type, hatched)
+            },
             ExperimentCommand::VisualizeJson { input, output } => commands::experiment::visualize::draw_bucket_chart_from_json(&input, &output),
-            ExperimentCommand::Report { name: _, output, publish, strip_counterexamples, json_output } => commands::experiment::report::invoke(mgr, experiment.unwrap(), output, publish, strip_counterexamples, json_output),
+            ExperimentCommand::Report { name: _, output, publish, strip_counterexamples, json_output, store } => {
+                let mut experiment = experiment.unwrap();
+                if let Some(path) = store {
+                    experiment.store = path;
+                }
+                commands::experiment::report::invoke(mgr, experiment, output, publish, strip_counterexamples, json_output)
+            },
             ExperimentCommand::PublishPage { name: _, output, strip_counterexamples } => commands::experiment::publish_page::invoke(mgr, experiment.unwrap(), output, strip_counterexamples),
             ExperimentCommand::List {} => commands::experiment::list::invoke(mgr),
         },
@@ -317,6 +335,9 @@ enum ExperimentCommand {
         /// These override parameters defined in test JSON files
         #[clap(long, value_parser = parse_key_value)]
         params: Vec<(String, String)>,
+        /// Override the path to the metric store (default: <experiment>/store.jsonl)
+        #[clap(long)]
+        store: Option<PathBuf>,
     },
     #[clap(name = "show", about = "Show the details of an experiment")]
     Show {
@@ -413,6 +434,9 @@ enum ExperimentCommand {
         /// e.g., --hatched 1,3 for every other group starting from index 1
         #[clap(long, value_parser, num_args = 0.., value_delimiter = ',')]
         hatched: Vec<usize>,
+        /// Override the path to the metric store (default: <experiment>/store.jsonl)
+        #[clap(long)]
+        store: Option<PathBuf>,
     },
     #[clap(
         name = "visualize-json",
@@ -453,6 +477,9 @@ enum ExperimentCommand {
         /// for serving a static `/json` endpoint alongside the HTML report.
         #[clap(long)]
         json_output: Option<PathBuf>,
+        /// Override the path to the metric store (default: <experiment>/store.jsonl)
+        #[clap(long)]
+        store: Option<PathBuf>,
     },
     #[clap(
         name = "publish-page",


### PR DESCRIPTION
## Summary
- Adds `--store <PATH>` flag to `etna experiment run`, `etna experiment visualize`, and `etna experiment report`.
- When supplied, the flag overrides `experiment.store` before invoke, pointing those commands at an alternate metrics file.
- Default behavior is unchanged — omitting the flag keeps using `<experiment>/store.jsonl`.

## Motivation
Currently the per-experiment store is hardcoded to `<experiment>/store.jsonl`. When iterating on an experiment (e.g., keeping a baseline store alongside an in-progress sweep, or running multiple cohorts and comparing them via `etna experiment report`), the only way to point at a different store is to physically swap the file in and out — an ad-hoc backup/restore dance that's easy to get wrong and clutters the workflow.

`--store` makes this a flag instead of a filesystem ritual.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — all 48 tests pass (29 unit + 19 integration; 0 failures)
- [x] `etna experiment {run,visualize,report} --help` shows the new flag with sensible help text
- [ ] Manual smoke: `etna experiment report --store /tmp/alt-store.jsonl` reads from the alternate path
- [ ] Manual smoke: `etna experiment run --store /tmp/alt-store.jsonl --tests <wl>` writes to the alternate path

🤖 Generated with [Claude Code](https://claude.com/claude-code)