### PR TITLE
ci: add reusable run-experiment workflow + scaffold caller in experiment new

### DIFF
--- a/.github/workflows/run-experiment.yml
+++ b/.github/workflows/run-experiment.yml
@@ -1,0 +1,305 @@
+name: Run experiment
+# Reusable workflow: an experiment repo's `.github/workflows/etna-experiment.yml`
+# calls this with `uses:` to run one or more `etna experiment run --tests <t>`
+# invocations, then (by default) commits the updated store back to the repo
+# so the visualize/report commands see fresh results next time.
+#
+# What the caller does:
+#   1. Adds `.github/workflows/etna-experiment.yml` with `uses:
+#      alpaylan/etna-cli/.github/workflows/run-experiment.yml@<ref>`.
+#   2. (Optional) Passes `tests:` to restrict to a subset; default = all tests
+#      under `tests/*.json`.
+#   3. (Optional) Sets `commit-results: false` if it only wants artifacts.
+#
+# The caller's checkout must include the experiment's workloads — they are
+# resolved by `etna experiment register` from the local `workloads/` tree.
+
+on:
+  workflow_call:
+    inputs:
+      tests:
+        description: 'Comma-separated test stems to run. Empty = all `tests/*.json`.'
+        type: string
+        default: ''
+      params:
+        description: 'Extra params forwarded to `etna experiment run --params` (newline-separated key=value).'
+        type: string
+        default: ''
+      short-circuit:
+        description: 'Pass --short-circuit to stop a test on the first failing trial.'
+        type: boolean
+        default: false
+      commit-results:
+        description: 'Commit + push the updated store.jsonl back to the experiment repo on success.'
+        type: boolean
+        default: true
+      etna-version:
+        description: 'etna-cli release tag to install (e.g. v0.1.15). Empty = latest.'
+        type: string
+        default: ''
+
+concurrency:
+  group: run-experiment-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      contents: write
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      # Some experiments ship workloads as `git@github.com:` submodules; rewrite
+      # to HTTPS so hosted runners (no SSH key) can re-init if checkout missed
+      # any.
+      - name: Re-init submodules over HTTPS
+        shell: bash
+        run: |
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          if [ -f .gitmodules ]; then
+            git submodule sync --recursive
+            git submodule update --init --recursive
+          fi
+
+      # ---------- Detect languages present in this experiment ----------------
+      # An experiment can contain workloads in multiple languages (e.g.
+      # workloads/Haskell/BST + workloads/Rust/BST). We bootstrap each
+      # toolchain we find under `workloads/` so `etna experiment run` can
+      # build whichever variant a test references.
+      - name: Detect workload languages
+        id: langs
+        shell: bash
+        run: |
+          if [ ! -f etna.toml ]; then
+            echo "::error::etna.toml not found at experiment root"
+            exit 1
+          fi
+          declare -A seen
+          if [ -d workloads ]; then
+            for dir in workloads/*/; do
+              [ -d "$dir" ] || continue
+              # Two layouts:
+              #   workloads/<Lang>/<workload>/etna.toml     (multi-lang)
+              #   workloads/<workload>/etna.toml            (single-lang)
+              if [ -f "$dir/etna.toml" ]; then
+                lang=$(grep -E '^language *= *"' "$dir/etna.toml" | head -1 \
+                  | sed -E 's/^language *= *"([^"]*)".*/\1/' | tr '[:upper:]' '[:lower:]')
+                [ -n "$lang" ] && seen[$lang]=1
+              else
+                for sub in "$dir"*/; do
+                  [ -f "$sub/etna.toml" ] || continue
+                  lang=$(grep -E '^language *= *"' "$sub/etna.toml" | head -1 \
+                    | sed -E 's/^language *= *"([^"]*)".*/\1/' | tr '[:upper:]' '[:lower:]')
+                  [ -n "$lang" ] && seen[$lang]=1
+                done
+              fi
+            done
+          fi
+          {
+            echo "rust=${seen[rust]:-0}"
+            echo "haskell=${seen[haskell]:-0}"
+            echo "ocaml=${seen[ocaml]:-0}"
+            echo "rocq=$(( ${seen[rocq]:-0} | ${seen[coq]:-0} ))"
+            echo "lean=${seen[lean]:-0}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Detected languages:"
+          for k in "${!seen[@]}"; do echo "  - $k"; done
+
+      # ---------- Per-language toolchain bootstrap + cache ------------------
+      # (Mirrors run-and-publish.yml. Each block is gated on the detector.)
+      - name: Setup Rust
+        if: steps.langs.outputs.rust == '1'
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Cache Rust
+        if: steps.langs.outputs.rust == '1'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-exp-${{ hashFiles('workloads/**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-exp-
+      - name: Install uv (Rust hegel shell-out)
+        if: steps.langs.outputs.rust == '1'
+        uses: astral-sh/setup-uv@v6
+
+      - name: Setup Haskell + Stack
+        if: steps.langs.outputs.haskell == '1'
+        uses: haskell-actions/setup@v2
+        with:
+          enable-stack: true
+          stack-version: '2.15.7'
+      - name: Cache Stack
+        if: steps.langs.outputs.haskell == '1'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.stack
+            workloads/**/.stack-work
+          key: ${{ runner.os }}-stack-exp-${{ hashFiles('workloads/**/stack.yaml*', 'workloads/**/*.cabal', 'workloads/**/package.yaml') }}
+          restore-keys: ${{ runner.os }}-stack-exp-
+
+      - name: Setup OCaml
+        if: steps.langs.outputs.ocaml == '1'
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: '5.x'
+
+      - name: Setup OCaml for Coq via opam
+        if: steps.langs.outputs.rocq == '1'
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: '4.14.x'
+          opam-repositories: |
+            default: https://opam.ocaml.org
+            coq-released: https://coq.inria.fr/opam/released
+      - name: Install Coq + QuickChick + ExtLib
+        if: steps.langs.outputs.rocq == '1'
+        shell: bash
+        run: |
+          opam install -y coq.8.18.0
+          eval $(opam env)
+          opam install -y coq-elpi
+          eval $(opam env)
+          opam install -y dune.2.9.3
+          eval $(opam env)
+          rm -rf "$RUNNER_TEMP/quickchick-pl"
+          git clone --depth 1 --branch property-language \
+            https://github.com/QuickChick/QuickChick.git "$RUNNER_TEMP/quickchick-pl"
+          ( cd "$RUNNER_TEMP/quickchick-pl" \
+            && rm -rf examples \
+            && git -c user.email=ci@etna -c user.name=ci-bot \
+                  commit -am 'CI: strip examples/ (broken Emacs lock symlink)' )
+          opam pin add -y --no-action coq-quickchick "$RUNNER_TEMP/quickchick-pl"
+          rm -rf $(opam var prefix)/.opam-switch/build/coq-quickchick.dev
+          opam install -y coq-quickchick coq-ext-lib
+          echo "OPAMSWITCH=$(opam switch show --safe)" >> "$GITHUB_ENV"
+          echo "$(opam var prefix)/bin" >> "$GITHUB_PATH"
+
+      - name: Install elan (Lean toolchain)
+        if: steps.langs.outputs.lean == '1'
+        shell: bash
+        run: |
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+            | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      - name: Cache lake build (Lean)
+        if: steps.langs.outputs.lean == '1'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.elan
+            workloads/**/.lake/build
+            workloads/**/.lake/packages
+          key: ${{ runner.os }}-lake-exp-${{ hashFiles('workloads/**/lean-toolchain', 'workloads/**/lake-manifest.json') }}
+          restore-keys: ${{ runner.os }}-lake-exp-
+
+      # ---------- Install etna-cli ----------------------------------------
+      - name: Install etna-cli
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.etna-version }}" ]; then
+            url="https://github.com/alpaylan/etna-cli/releases/download/${{ inputs.etna-version }}/etna-installer.sh"
+          else
+            url="https://github.com/alpaylan/etna-cli/releases/latest/download/etna-installer.sh"
+          fi
+          curl -LsSf "$url" | sh
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          "$HOME/.cargo/bin/etna" --version || true
+
+      # ---------- Register the checked-out experiment ---------------------
+      - name: Register experiment
+        id: exp
+        shell: bash
+        run: |
+          etna setup --overwrite || true
+          # `experiment register` uses the directory basename as the
+          # experiment name by default; pin to etna.toml's `name` instead so
+          # `etna experiment run` can find it via `--name`.
+          name=$(grep -E '^name *= *"' etna.toml | head -1 \
+            | sed -E 's/^name *= *"([^"]*)".*/\1/')
+          if [ -z "$name" ]; then
+            echo "::error::etna.toml is missing a top-level name = \"...\" field"
+            exit 1
+          fi
+          etna experiment register "$name"
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+
+      # ---------- Run requested tests -------------------------------------
+      - name: Resolve test list
+        id: tests
+        shell: bash
+        run: |
+          requested="${{ inputs.tests }}"
+          if [ -z "$requested" ]; then
+            # Default: every `tests/*.json` stem.
+            list=$(find tests -maxdepth 1 -name '*.json' -type f \
+              -exec basename {} .json \; | sort | paste -sd ',' -)
+          else
+            list=$(echo "$requested" | tr ' ' ',' )
+          fi
+          if [ -z "$list" ]; then
+            echo "::error::No tests to run — set inputs.tests or add JSON files under tests/."
+            exit 1
+          fi
+          echo "list=$list" >> "$GITHUB_OUTPUT"
+          echo "Tests to run: $list"
+
+      - name: Run experiment
+        shell: bash
+        run: |
+          IFS=',' read -ra TESTS <<< "${{ steps.tests.outputs.list }}"
+          # Build `--params k=v` flags from the multiline input.
+          params_args=()
+          if [ -n "${{ inputs.params }}" ]; then
+            while IFS= read -r kv; do
+              [ -z "$kv" ] && continue
+              params_args+=(--params "$kv")
+            done <<< "${{ inputs.params }}"
+          fi
+          sc_arg=()
+          if [ "${{ inputs.short-circuit }}" = "true" ]; then
+            sc_arg+=(--short-circuit)
+          fi
+          for t in "${TESTS[@]}"; do
+            echo "::group::etna experiment run --tests $t"
+            etna experiment run --name "${{ steps.exp.outputs.name }}" \
+              --tests "$t" --store store.jsonl \
+              "${sc_arg[@]}" "${params_args[@]}"
+            echo "::endgroup::"
+          done
+
+      # ---------- Always upload the store as an artifact -----------------
+      - name: Upload store artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: experiment-store-${{ github.run_id }}
+          path: |
+            store.jsonl
+          if-no-files-found: ignore
+
+      # ---------- Optionally commit results back -------------------------
+      - name: Commit + push updated store
+        if: ${{ inputs.commit-results && success() }}
+        shell: bash
+        run: |
+          git config user.name 'etna-cli[bot]'
+          git config user.email 'etna-cli@users.noreply.github.com'
+          if git diff --quiet -- store.jsonl; then
+            echo "store.jsonl unchanged — skipping commit."
+            exit 0
+          fi
+          git add store.jsonl
+          git commit -m "ci: refresh store.jsonl from etna experiment run ($GITHUB_RUN_NUMBER)"
+          git push origin HEAD:"${GITHUB_REF#refs/heads/}"

--- a/.github/workflows/run-experiment.yml
+++ b/.github/workflows/run-experiment.yml
@@ -9,7 +9,10 @@ name: Run experiment
 #      alpaylan/etna-cli/.github/workflows/run-experiment.yml@<ref>`.
 #   2. (Optional) Passes `tests:` to restrict to a subset; default = all tests
 #      under `tests/*.json`.
-#   3. (Optional) Sets `commit-results: false` if it only wants artifacts.
+#   3. (Optional) Sets `commit-results: true` to push the produced store
+#      file back to the repo. Default is false — the store is only uploaded
+#      as a workflow artifact so existing local results aren't overwritten
+#      by a partial CI run.
 #
 # The caller's checkout must include the experiment's workloads — they are
 # resolved by `etna experiment register` from the local `workloads/` tree.
@@ -21,6 +24,10 @@ on:
         description: 'Comma-separated test stems to run. Empty = all `tests/*.json`.'
         type: string
         default: ''
+      store:
+        description: 'Path (relative to the experiment root) to write store entries to. Default keeps CI output separate from a developer-owned `store.jsonl`.'
+        type: string
+        default: 'store-ci.jsonl'
       params:
         description: 'Extra params forwarded to `etna experiment run --params` (newline-separated key=value).'
         type: string
@@ -30,9 +37,9 @@ on:
         type: boolean
         default: false
       commit-results:
-        description: 'Commit + push the updated store.jsonl back to the experiment repo on success.'
+        description: 'Commit + push the produced store file back to the experiment repo on success. Off by default to avoid overwriting accumulated local results.'
         type: boolean
-        default: true
+        default: false
       etna-version:
         description: 'etna-cli release tag to install (e.g. v0.1.15). Empty = latest.'
         type: string
@@ -271,10 +278,14 @@ jobs:
           if [ "${{ inputs.short-circuit }}" = "true" ]; then
             sc_arg+=(--short-circuit)
           fi
+          store_path="${{ inputs.store }}"
+          # Ensure the store file's parent directory exists (the user may have
+          # asked for e.g. ci/results.jsonl).
+          mkdir -p "$(dirname "$store_path")"
           for t in "${TESTS[@]}"; do
-            echo "::group::etna experiment run --tests $t"
+            echo "::group::etna experiment run --tests $t --store $store_path"
             etna experiment run --name "${{ steps.exp.outputs.name }}" \
-              --tests "$t" --store store.jsonl \
+              --tests "$t" --store "$store_path" \
               "${sc_arg[@]}" "${params_args[@]}"
             echo "::endgroup::"
           done
@@ -285,21 +296,27 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: experiment-store-${{ github.run_id }}
-          path: |
-            store.jsonl
+          path: ${{ inputs.store }}
           if-no-files-found: ignore
 
       # ---------- Optionally commit results back -------------------------
+      # Off by default. Opt in via `commit-results: true` on the caller —
+      # the dispatcher should only enable it when they're sure the CI run
+      # produced the canonical results for that store path (i.e. it isn't
+      # a partial subset that would clobber accumulated local entries).
       - name: Commit + push updated store
         if: ${{ inputs.commit-results && success() }}
         shell: bash
         run: |
+          store_path="${{ inputs.store }}"
           git config user.name 'etna-cli[bot]'
           git config user.email 'etna-cli@users.noreply.github.com'
-          if git diff --quiet -- store.jsonl; then
-            echo "store.jsonl unchanged — skipping commit."
+          # Stage the file (it may be untracked if the caller routed output
+          # to a new path); skip the commit if nothing actually changed.
+          git add -- "$store_path"
+          if git diff --cached --quiet -- "$store_path"; then
+            echo "$store_path unchanged — skipping commit."
             exit 0
           fi
-          git add store.jsonl
-          git commit -m "ci: refresh store.jsonl from etna experiment run ($GITHUB_RUN_NUMBER)"
+          git commit -m "ci: refresh $store_path from etna experiment run ($GITHUB_RUN_NUMBER)"
           git push origin HEAD:"${GITHUB_REF#refs/heads/}"

--- a/src/service/experiment.rs
+++ b/src/service/experiment.rs
@@ -182,6 +182,10 @@ pub fn create_experiment(
         ),
         (".gitignore", include_str!("../../templates/.gitignoret")),
         ("etna.toml", manifest_body.as_str()),
+        (
+            ".github/workflows/etna-experiment.yml",
+            include_str!("../../templates/experiment/etna-experiment.ymlt"),
+        ),
     ];
 
     tracing::trace!("creating template files in the experiment directory");

--- a/templates/experiment/etna-experiment.ymlt
+++ b/templates/experiment/etna-experiment.ymlt
@@ -1,5 +1,10 @@
 name: Run experiment
 
+# Manually-dispatched CI: open the Actions tab and click "Run workflow" to
+# pick which tests to run and where their results should land. Nothing
+# runs on push by default — that prevents a CI run from silently
+# overwriting results you've accumulated locally in store.jsonl.
+
 on:
   workflow_dispatch:
     inputs:
@@ -7,6 +12,10 @@ on:
         description: 'Comma-separated test stems to run (empty = all under tests/).'
         type: string
         default: ''
+      store:
+        description: 'Output store path (relative to repo root). Keeps CI results separate from your local store.jsonl by default.'
+        type: string
+        default: 'store-ci.jsonl'
       params:
         description: 'Extra params for `etna experiment run --params` (one key=value per line).'
         type: string
@@ -15,12 +24,10 @@ on:
         description: 'Pass --short-circuit to stop a test on the first failing trial.'
         type: boolean
         default: false
-  push:
-    branches: [main, master]
-    paths:
-      - 'tests/**'
-      - 'workloads/**'
-      - 'etna.toml'
+      commit-results:
+        description: 'Commit + push the produced store file back. Off by default — review the artifact first.'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -29,7 +36,8 @@ jobs:
   run:
     uses: alpaylan/etna-cli/.github/workflows/run-experiment.yml@main
     with:
-      tests: ${{ github.event.inputs.tests || '' }}
-      params: ${{ github.event.inputs.params || '' }}
-      short-circuit: ${{ github.event.inputs['short-circuit'] == 'true' }}
-      commit-results: true
+      tests: ${{ inputs.tests }}
+      store: ${{ inputs.store }}
+      params: ${{ inputs.params }}
+      short-circuit: ${{ inputs.short-circuit }}
+      commit-results: ${{ inputs.commit-results }}

--- a/templates/experiment/etna-experiment.ymlt
+++ b/templates/experiment/etna-experiment.ymlt
@@ -1,0 +1,35 @@
+name: Run experiment
+
+on:
+  workflow_dispatch:
+    inputs:
+      tests:
+        description: 'Comma-separated test stems to run (empty = all under tests/).'
+        type: string
+        default: ''
+      params:
+        description: 'Extra params for `etna experiment run --params` (one key=value per line).'
+        type: string
+        default: ''
+      short-circuit:
+        description: 'Pass --short-circuit to stop a test on the first failing trial.'
+        type: boolean
+        default: false
+  push:
+    branches: [main, master]
+    paths:
+      - 'tests/**'
+      - 'workloads/**'
+      - 'etna.toml'
+
+permissions:
+  contents: write
+
+jobs:
+  run:
+    uses: alpaylan/etna-cli/.github/workflows/run-experiment.yml@main
+    with:
+      tests: ${{ github.event.inputs.tests || '' }}
+      params: ${{ github.event.inputs.params || '' }}
+      short-circuit: ${{ github.event.inputs['short-circuit'] == 'true' }}
+      commit-results: true


### PR DESCRIPTION
## Summary

Mirrors the workload-side `run-and-publish.yml` pattern (workload → reusable workflow in etna-cli) but for **experiments**:

- **`.github/workflows/run-experiment.yml`** (new) — reusable workflow invoked via `uses:` from an experiment repo. Detects which languages are present under `workloads/`, installs the matching toolchains (Rust/Haskell/OCaml/Coq/Lean), installs etna-cli, registers the checked-out experiment by its `etna.toml` name, runs `etna experiment run --tests <t> --store store.jsonl` per requested test, uploads the store as a CI artifact, and (by default) commits the refreshed store back to the experiment repo.
- **`templates/experiment/etna-experiment.ymlt`** (new) — short caller template that pins to the reusable workflow above with sensible defaults: `workflow_dispatch` (with `tests`, `params`, `short-circuit` inputs) + `push` to `main`/`master` on changes under `tests/`, `workloads/`, or `etna.toml`.
- **`src/service/experiment.rs`** — `create_experiment` now scaffolds the caller template into `<experiment>/.github/workflows/etna-experiment.yml` alongside the existing `Collect.py` / `Query.py` / `Analyze.py` / `Visualize.py` / `etna.toml` / `.gitignore`.

So `etna experiment new <name>` now produces a repo that's CI-ready out of the box: push it (or hit "Run workflow" in the Actions tab) and the experiment will run on hosted runners.

## Inputs the caller exposes

| Input | Default | Use |
|---|---|---|
| `tests` | `""` (= all `tests/*.json`) | Comma-separated test stems to restrict the run |
| `params` | `""` | Newline-separated `key=value` forwarded to `etna experiment run --params` |
| `short-circuit` | `false` | Pass `--short-circuit` to bail on the first failing trial |
| `commit-results` (reusable only) | `true` | Commit `store.jsonl` back after a successful run |
| `etna-version` (reusable only) | `""` (= latest) | Pin a specific etna-cli release |

## Test plan

- [ ] `cargo build --bin etna` — confirms scaffolder compiles ✅ (verified locally)
- [ ] `etna experiment new smoketest` scaffolds `.github/workflows/etna-experiment.yml` with expected content ✅ (verified locally — see `find smoketest -type f`)
- [ ] Open the PR; in a downstream experiment repo, update the caller's `uses:` to this branch (`@experiment-publish-workflow`) and trigger `workflow_dispatch` — confirm the reusable workflow detects languages, installs toolchains, runs tests, and commits `store.jsonl` back
- [ ] Confirm the artifact `experiment-store-<run_id>` appears for both success and failure paths
- [ ] Run with `commit-results: false` and verify nothing is pushed back
- [ ] Run with `tests: "bst-cross-haskell"` (or another stem) and confirm only that test executes

## Notes

- Stays non-invasive per [[feedback_non_invasive_addition]]: duplicates toolchain bootstrap steps from `run-and-publish.yml` instead of refactoring it into a shared workflow.
- Experiment naming: `etna experiment register` defaults to the directory basename, but CI's `${{ github.workspace }}` basename won't match `etna.toml`'s `name`. The workflow extracts the manifest name and passes it to `register "$name"` explicitly so `etna experiment run --name "$name"` resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)