### PR TITLE
Add prebuilt Rocq toolchain image for run-experiment's rocq-image

### DIFF
--- a/.github/workflows/build-rocq-image.yml
+++ b/.github/workflows/build-rocq-image.yml
@@ -1,0 +1,67 @@
+name: Build Rocq toolchain image
+
+# Builds and pushes the prebuilt Coq + QuickChick(programmable-pbt) + ExtLib
+# toolchain image that run-experiment.yml's `rocq-image` input points at, so
+# experiment CI can skip the ~30-min from-source toolchain build. (etna itself
+# is installed fresh per run by run-experiment.yml, not baked into the image.)
+#
+# Run it once to populate the registry, then again whenever docker/rocq.Dockerfile
+# (or the QuickChick branch / OCaml / Coq pins it captures) changes.
+#
+# First-time setup: after the first successful push, open the package at
+# https://github.com/users/<owner>/packages/container/etna-quickchick/settings
+# and set its visibility to **Public** so experiment repos under the same owner
+# can pull it without per-repo registry grants.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag to push (under ghcr.io/<owner>/etna-quickchick).'
+        type: string
+        default: 'programmable-pbt'
+  push:
+    branches: [main]
+    paths:
+      - 'docker/rocq.Dockerfile'
+      - '.github/workflows/build-rocq-image.yml'
+
+concurrency:
+  group: build-rocq-image-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+
+      # ghcr image refs must be lowercase; the owner login already is, but
+      # normalize defensively.
+      - name: Resolve image ref
+        id: img
+        run: echo "ref=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/etna-quickchick" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/rocq.Dockerfile
+          push: true
+          tags: ${{ steps.img.outputs.ref }}:${{ inputs.tag || 'programmable-pbt' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/run-experiment.yml
+++ b/.github/workflows/run-experiment.yml
@@ -169,8 +169,10 @@ jobs:
         with:
           ocaml-compiler: "5.x"
 
+      # Skipped when `rocq-image` is set — that prebuilt container already
+      # carries the AFL switch + Coq + QuickChick (see docker/rocq.Dockerfile).
       - name: Setup OCaml for Coq via opam
-        if: steps.langs.outputs.rocq == '1'
+        if: steps.langs.outputs.rocq == '1' && inputs.rocq-image == ''
         uses: ocaml/setup-ocaml@v3
         with:
           # AFL-instrumented compiler built in one shot: the +options variant plus
@@ -184,7 +186,7 @@ jobs:
             default: https://opam.ocaml.org
             coq-released: https://coq.inria.fr/opam/released
       - name: Install Coq + QuickChick + ExtLib
-        if: steps.langs.outputs.rocq == '1'
+        if: steps.langs.outputs.rocq == '1' && inputs.rocq-image == ''
         shell: bash
         run: |
           rm -rf "$RUNNER_TEMP/quickchick-pl"

--- a/docker/rocq.Dockerfile
+++ b/docker/rocq.Dockerfile
@@ -1,0 +1,77 @@
+# Prebuilt Rocq toolchain image for `run-experiment.yml`'s `rocq-image` input.
+#
+# It bakes exactly what the from-source path in run-experiment.yml installs, so
+# experiment CI can run inside this container and skip the ~30-min build:
+#   * an AFL-instrumented OCaml 5.2.1 switch (the fuzzing workloads read AFL
+#     coverage via shared memory from the compiled OCaml at runtime),
+#   * Coq (Rocq 9.x) + QuickChick (alpaylan/QuickChick#programmable-pbt) + the
+#     deps that branch's opam file declares (dune, mathcomp-ssreflect,
+#     simple-io, ext-lib, ...).
+#
+# etna itself is NOT baked in: run-experiment.yml installs it fresh every run
+# (to pick up the latest release) and puts it on PATH, so a copy here would only
+# go stale and tie the image to etna's release arch matrix.
+#
+# Built/pushed by .github/workflows/build-rocq-image.yml to
+# ghcr.io/<owner>/etna-quickchick:<tag>. Rebuild it whenever the QuickChick
+# branch or the OCaml/Coq pins below change.
+#
+# Built on plain ubuntu (not coqorg/coq) because the AFL OCaml variant means
+# Coq has to be compiled against that switch anyway, and running as root keeps
+# GitHub Actions `container:` jobs — which mount the workspace as root — free of
+# the permission dance stock Coq images need.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# opam + the system bits Coq/QuickChick/dune build against, plus the tools the
+# experiment job needs at runtime inside this container: git (checkout +
+# QuickChick clone), curl/ca-certificates (run-experiment.yml's per-run etna
+# install), sudo (some actions expect it), rsync/unzip (actions/cache +
+# upload-artifact).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl git sudo \
+        build-essential m4 pkg-config \
+        libgmp-dev \
+        bubblewrap rsync unzip \
+        opam \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV OPAMROOT=/root/.opam
+ENV OPAMYES=1
+ENV OPAMCONFIRMLEVEL=unsafe-yes
+
+# `--disable-sandboxing` because bubblewrap can't get the namespaces it needs
+# inside an unprivileged `docker build`.
+RUN opam init --bare --disable-sandboxing --yes \
+ && opam repository add coq-released https://coq.inria.fr/opam/released --dont-select --yes
+
+# AFL switch — mirrors setup-ocaml's `ocaml-variants.5.2.1+options,ocaml-option-afl`.
+RUN opam switch create etna ocaml-variants.5.2.1+options ocaml-option-afl \
+        --repos=default,coq-released --yes
+
+# Bake the switch into the image env. GitHub Actions runs each `run:` step in a
+# fresh non-login shell that never sources `opam env`, so coqc/dune/quickchick
+# must be discoverable from the image ENV alone. These are the standard opam
+# switch paths for OPAMROOT=/root/.opam, switch `etna`.
+ENV OPAMSWITCH=etna
+ENV OPAM_SWITCH_PREFIX=/root/.opam/etna
+ENV PATH=/root/.opam/etna/bin:$PATH
+ENV CAML_LD_LIBRARY_PATH=/root/.opam/etna/lib/stublibs:/root/.opam/etna/lib/ocaml/stublibs
+ENV OCAML_TOPLEVEL_PATH=/root/.opam/etna/lib/toplevel
+ENV OCAMLPATH=/root/.opam/etna/lib
+
+# QuickChick straight from the clone: opam reads its opam file, pulls the deps
+# it declares, then builds and installs into the switch. No pins, no hard-coded
+# versions — identical to run-experiment.yml's host path.
+RUN git clone --depth 1 --branch programmable-pbt \
+        https://github.com/alpaylan/QuickChick.git /tmp/quickchick-pl \
+ && eval "$(opam env --switch=etna --set-switch)" \
+ && opam install -y /tmp/quickchick-pl \
+ && opam clean --all-switches --download-cache --logs --repo-cache \
+ && rm -rf /tmp/quickchick-pl
+
+# Fail the build early if the toolchain the experiment job depends on isn't on
+# PATH from the image ENV alone (i.e. without `opam env`) — exactly the
+# condition each GitHub Actions step shell runs under.
+RUN coqc --version && dune --version


### PR DESCRIPTION
## Why

`run-experiment.yml`'s `rocq-image` input runs the job inside a prebuilt container to skip the ~30‑min from‑source Coq/QuickChick build — but **nothing ever built that image**. Experiment repos defaulting `rocq-image` to `ghcr.io/alpaylan/etna-quickchick:programmable-pbt` fail immediately with `manifest unknown` ([example run](https://github.com/alpaylan/programmable-pbt-artifact/actions/runs/26464980372/job/77922710516)). This PR adds the missing half.

## What

- **`docker/rocq.Dockerfile`** — reproduces the from‑source path exactly: AFL‑instrumented OCaml 5.2.1 switch (`ocaml-variants.5.2.1+options` + `ocaml-option-afl`) + Coq (Rocq **9.1.1**) + QuickChick (`alpaylan/QuickChick#programmable-pbt`) + the deps its opam file declares (mathcomp‑ssreflect, simple‑io, ext‑lib, …). The opam switch paths are baked into the image `ENV` so each Actions step's non‑login shell finds `coqc`/`dune` without `opam env`.
  - Needs `libgmp-dev` in the apt layer: a bare container has no `setup-ocaml` to auto‑install opam depexts, so Coq's `zarith` → `conf-gmp` → `libgmp-dev` must be present (this was the first thing the local build caught).
  - **etna is not baked in** — `run-experiment.yml` installs it fresh per run (latest release), so a copy here would only go stale and tie the image to etna's release‑arch matrix.
- **`.github/workflows/build-rocq-image.yml`** — `workflow_dispatch` (+ push on Dockerfile change) that builds and pushes to `ghcr.io/<owner>/etna-quickchick`.
- **`run-experiment.yml`** — gate the "Setup OCaml for Coq" and "Install Coq + QuickChick + ExtLib" steps on `inputs.rocq-image == ''`, so supplying an image actually *uses* it instead of rebuilding the toolchain inside it.

## Validation

Built the image locally (arm64) and confirmed in a fresh non‑login shell:

\`\`\`
$ docker run --rm etna-quickchick:local-test sh -c 'coqc /tmp/t.v'   # imports QuickChick + mathcomp.ssreflect
=== QUICKCHICK + SSREFLECT LOAD OK ===
\`\`\`

## After merge (one‑time)

1. Run **Build Rocq toolchain image** (Actions → workflow_dispatch) to populate the registry.
2. Set the `etna-quickchick` package visibility to **Public** so experiment repos under the same owner can pull it.
3. Re‑run the experiment workflow — it now boots straight into the prebuilt toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)