### PR TITLE
Fix dubious-ownership git failure in rocq-image container jobs

### DIFF
--- a/.github/workflows/run-experiment.yml
+++ b/.github/workflows/run-experiment.yml
@@ -76,6 +76,13 @@ jobs:
       - name: Re-init submodules over HTTPS
         shell: bash
         run: |
+          # When the job runs in a `rocq-image` container it runs as root, but
+          # the checked-out workspace (and every nested submodule working dir)
+          # is owned by the host-runner uid — so git aborts any operation with
+          # "detected dubious ownership". Whitelist all paths before touching
+          # git. Set globally so it also covers git the experiment run shells
+          # out to later. No-op on the host runner (which owns its workspace).
+          git config --global --add safe.directory '*'
           git config --global url."https://github.com/".insteadOf "git@github.com:"
           if [ -f .gitmodules ]; then
             git submodule sync --recursive


### PR DESCRIPTION
## Why

Follow-up to #57. With the prebuilt `rocq-image` now in place, the experiment job runs **inside the container as root**, while the checked-out workspace (and every nested submodule working dir) is owned by the host-runner uid. git refuses to operate on a repo it doesn't "own", so the **Re-init submodules over HTTPS** step fails:

```
fatal: detected dubious ownership in repository at '/__w/programmable-pbt-artifact/programmable-pbt-artifact'
##[error]Process completed with exit code 128.
```

…and every subsequent step (`Install etna-cli`, `Register experiment`, `Run experiment`) is skipped. This never happened on the host runner, which owns its workspace. `actions/checkout` whitelists its *own* git operations, but the explicit re-init step doesn't inherit that.

## Fix

Add `git config --global --add safe.directory '*'` at the top of the re-init step, before any git command. Setting it globally means it also covers any git the experiment run shells out to later. No-op on the host path (the runner owns its workspace), so the non-container path is unaffected.

## Validation

1. Surfaced by an actual container run of `bst-proplang-rocq` ([run](https://github.com/alpaylan/programmable-pbt-artifact/actions/runs/26487450594)): the image pulled and `actions/checkout` (incl. all submodules) succeeded inside it — confirming #57 works — then this step was the next failure.
2. Reproduced and fixed locally against the toolchain image (`git 2.43.0`, as root, repo owned by uid 1001):

```
WITHOUT fix:  git submodule sync/update -> fatal: detected dubious ownership ... exit=128
WITH fix:     git submodule sync/update -> exit=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)